### PR TITLE
[codex] add deep-link landing pages

### DIFF
--- a/src/app/collection/page.tsx
+++ b/src/app/collection/page.tsx
@@ -1,0 +1,8 @@
+import DeepLinkLandingPage from "@/components/DeepLinkLandingPage";
+import { collectionLandingPageConfig } from "@/lib/deep-link-landing-pages";
+
+export const metadata = collectionLandingPageConfig.metadata;
+
+export default function CollectionPage() {
+  return <DeepLinkLandingPage config={collectionLandingPageConfig} />;
+}

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -1,0 +1,8 @@
+import DeepLinkLandingPage from "@/components/DeepLinkLandingPage";
+import { scanLandingPageConfig } from "@/lib/deep-link-landing-pages";
+
+export const metadata = scanLandingPageConfig.metadata;
+
+export default function ScanPage() {
+  return <DeepLinkLandingPage config={scanLandingPageConfig} />;
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -15,6 +15,24 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.3,
     },
     {
+      url: 'https://www.barrelbook.app/scan',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://www.barrelbook.app/collection',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: 'https://www.barrelbook.app/store-picks',
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
       url: 'https://www.barrelbook.app/terms',
       lastModified: new Date(),
       changeFrequency: 'monthly',

--- a/src/app/store-picks/page.tsx
+++ b/src/app/store-picks/page.tsx
@@ -1,0 +1,8 @@
+import DeepLinkLandingPage from "@/components/DeepLinkLandingPage";
+import { storePicksLandingPageConfig } from "@/lib/deep-link-landing-pages";
+
+export const metadata = storePicksLandingPageConfig.metadata;
+
+export default function StorePicksPage() {
+  return <DeepLinkLandingPage config={storePicksLandingPageConfig} />;
+}

--- a/src/components/AppStoreBadgeLink.tsx
+++ b/src/components/AppStoreBadgeLink.tsx
@@ -1,0 +1,39 @@
+import Image from "next/image";
+import { APP_STORE_URL } from "@/lib/app-store";
+
+type AppStoreBadgeLinkProps = {
+  className?: string;
+  imageClassName?: string;
+  width?: number;
+  height?: number;
+  priority?: boolean;
+  ariaLabel?: string;
+};
+
+export default function AppStoreBadgeLink({
+  className = "inline-flex items-center",
+  imageClassName,
+  width = 180,
+  height = 60,
+  priority = false,
+  ariaLabel = "Download on the App Store",
+}: AppStoreBadgeLinkProps) {
+  return (
+    <a
+      href={APP_STORE_URL}
+      aria-label={ariaLabel}
+      className={className}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <Image
+        src="/badges/app-store.svg"
+        alt="Download on the App Store"
+        width={width}
+        height={height}
+        priority={priority}
+        className={imageClassName}
+      />
+    </a>
+  );
+}

--- a/src/components/AppStoreRatingLink.tsx
+++ b/src/components/AppStoreRatingLink.tsx
@@ -1,0 +1,29 @@
+import { Star } from "lucide-react";
+import { APP_STORE_RATING_COUNT, APP_STORE_URL } from "@/lib/app-store";
+
+type AppStoreRatingLinkProps = {
+  className?: string;
+};
+
+export default function AppStoreRatingLink({
+  className = "inline-flex items-center gap-2 text-sm text-gray-300 hover:text-white transition-colors",
+}: AppStoreRatingLinkProps) {
+  return (
+    <a
+      href={APP_STORE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Read ${APP_STORE_RATING_COUNT} five-star App Store reviews`}
+      className={className}
+    >
+      <span className="flex" aria-hidden="true">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <Star key={i} className="w-4 h-4 text-[#D2691E] fill-current" />
+        ))}
+      </span>
+      <span>
+        <span className="font-semibold text-white">{APP_STORE_RATING_COUNT}</span> five-star ratings on the App Store
+      </span>
+    </a>
+  );
+}

--- a/src/components/DeepLinkLandingPage.tsx
+++ b/src/components/DeepLinkLandingPage.tsx
@@ -1,0 +1,269 @@
+import Image from "next/image";
+import { Check, ChevronDown } from "lucide-react";
+import AppStoreBadgeLink from "@/components/AppStoreBadgeLink";
+import AppStoreRatingLink from "@/components/AppStoreRatingLink";
+import HeroVideo from "@/components/HeroVideo";
+import PhoneFrame from "@/components/PhoneFrame";
+import PricingTeaser from "@/components/PricingTeaser";
+import ReviewCard from "@/components/ReviewCard";
+import SiteFooter from "@/components/SiteFooter";
+import SiteHeader from "@/components/SiteHeader";
+import type { LandingPageConfig, ScreenshotConfig } from "@/lib/deep-link-landing-pages";
+
+type DeepLinkLandingPageProps = {
+  config: LandingPageConfig;
+};
+
+function renderPhoneScreenshot(
+  screenshot: ScreenshotConfig,
+  index: number,
+  sizes = "(max-width: 768px) 60vw, 320px",
+) {
+  return (
+    <PhoneFrame
+      key={`${screenshot.src}-${index}`}
+      ariaLabel={screenshot.alt}
+      width={screenshot.width ?? 886}
+      height={screenshot.height ?? 1920}
+      className={screenshot.className}
+    >
+      <div className="relative h-full w-full">
+        <Image
+          src={screenshot.src}
+          alt={screenshot.alt}
+          fill
+          sizes={sizes}
+          className="object-cover"
+        />
+      </div>
+    </PhoneFrame>
+  );
+}
+
+function getMediaGridClass(count: number) {
+  switch (count) {
+    case 2:
+      return "md:grid-cols-2";
+    case 3:
+      return "md:grid-cols-3";
+    default:
+      return "md:grid-cols-1";
+  }
+}
+
+export default function DeepLinkLandingPage({
+  config,
+}: DeepLinkLandingPageProps) {
+  return (
+    <div className="min-h-screen bg-[#0A0A0A] text-white">
+      <SiteHeader
+        navItems={[
+          { href: `#${config.strip.id}`, label: "How it works" },
+          { href: "#pricing", label: "Pricing" },
+          { href: "#faq", label: "FAQ" },
+        ]}
+      />
+
+      <main>
+        <section className="relative overflow-hidden pt-28 pb-12 px-4 sm:px-6 lg:px-8">
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(210,105,30,0.18),transparent_32%),radial-gradient(circle_at_top_right,rgba(255,255,255,0.05),transparent_24%)]"
+          />
+
+          <div className="relative max-w-7xl mx-auto">
+            <div className="grid items-center gap-10 lg:grid-cols-12 lg:gap-12">
+              <div className="text-center lg:col-span-7 lg:text-left">
+                <div className="inline-flex items-center rounded-full border border-[#333333] bg-[#1A1A1A] px-4 py-2 mb-6 text-sm text-gray-300">
+                  {config.hero.eyebrow}
+                </div>
+
+                <h1 className="text-5xl md:text-6xl leading-tight mb-6">
+                  {config.hero.title}
+                </h1>
+
+                <p className="text-xl text-gray-400 mb-6 max-w-4xl mx-auto lg:mx-0 leading-relaxed">
+                  {config.hero.description}
+                </p>
+
+                <AppStoreRatingLink className="inline-flex items-center gap-2 mb-6 text-sm text-gray-300 hover:text-white transition-colors" />
+
+                <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start items-center mb-4">
+                  <AppStoreBadgeLink width={180} height={60} priority />
+                </div>
+
+                <p className="text-sm text-gray-500">
+                  Free to start • No credit card required
+                </p>
+              </div>
+
+              <div className="lg:col-span-5 flex justify-center lg:justify-end">
+                {config.hero.media.kind === "video" ? (
+                  <HeroVideo
+                    src={config.hero.media.src}
+                    poster={config.hero.media.poster}
+                    ariaLabel={config.hero.media.ariaLabel}
+                    width={config.hero.media.width}
+                    height={config.hero.media.height}
+                    className={config.hero.media.className}
+                  />
+                ) : (
+                  <div className="flex items-end justify-center gap-4">
+                    {config.hero.media.screenshots.map((screenshot, index) => {
+                      const visibilityClass = screenshot.hideOnMobile ? "hidden sm:block" : "";
+                      const className = `${visibilityClass} ${screenshot.className ?? ""}`.trim();
+
+                      return renderPhoneScreenshot(
+                        { ...screenshot, className },
+                        index,
+                        index === 0
+                          ? "(max-width: 768px) 66vw, 280px"
+                          : "(max-width: 768px) 0px, 220px",
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="py-12 px-4 sm:px-6 lg:px-8">
+          <div className="max-w-7xl mx-auto rounded-3xl border border-[#333333] bg-[#111111] p-8 md:p-10">
+            <div className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-start">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#D2691E] mb-4">
+                  {config.proof.eyebrow}
+                </p>
+                <h2 className="text-3xl md:text-4xl leading-tight mb-6">
+                  {config.proof.title}
+                </h2>
+
+                <ul className="space-y-4">
+                  {config.proof.bullets.map((bullet) => (
+                    <li key={bullet} className="flex items-start gap-3">
+                      <Check className="w-5 h-5 text-[#D2691E] mt-0.5 flex-shrink-0" />
+                      <span className="text-base text-gray-300 leading-relaxed">{bullet}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <ReviewCard review={config.proof.review} featured className="bg-[#0D0D0D]" />
+            </div>
+          </div>
+        </section>
+
+        <section id={config.strip.id} className="py-12 px-4 sm:px-6 lg:px-8">
+          <div className="max-w-7xl mx-auto">
+            <div className="max-w-4xl mb-10">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#D2691E] mb-4">
+                {config.strip.eyebrow}
+              </p>
+              <h2 className="text-3xl md:text-4xl leading-tight mb-4">
+                {config.strip.title}
+              </h2>
+              <p className="text-lg text-gray-400 leading-relaxed">
+                {config.strip.description}
+              </p>
+            </div>
+
+            <div className={`grid gap-6 ${getMediaGridClass(config.strip.media.length)} justify-items-center mb-10`}>
+              {config.strip.media.map((screenshot, index) =>
+                renderPhoneScreenshot(
+                  { ...screenshot, className: "w-full max-w-[220px] sm:max-w-[240px]" },
+                  index,
+                ),
+              )}
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-3">
+              {config.strip.items.map((item, index) => (
+                <div
+                  key={item.title}
+                  className="rounded-2xl border border-[#333333] bg-[#121212] p-6"
+                >
+                  <div className="mb-4 inline-flex items-center justify-center rounded-full bg-[#1A1A1A] px-3 py-1 text-sm font-semibold text-[#D2691E]">
+                    {config.strip.variant === "steps" ? `${index + 1}` : "Built for"}
+                  </div>
+                  <h3 className="text-xl mb-3">{item.title}</h3>
+                  <p className="text-gray-400 leading-relaxed">{item.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="py-16 px-4 sm:px-6 lg:px-8 bg-[#1A1A1A]">
+          <div className="max-w-7xl mx-auto">
+            <div className="text-center mb-10 max-w-4xl mx-auto">
+              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#D2691E] mb-4">
+                {config.reviews.eyebrow}
+              </p>
+              <h2 className="text-3xl md:text-4xl leading-tight mb-4">
+                {config.reviews.title}
+              </h2>
+              <p className="text-lg text-gray-400 leading-relaxed">
+                {config.reviews.description}
+              </p>
+            </div>
+
+            <div className="grid gap-6 md:grid-cols-2">
+              {config.reviews.items.map((review) => (
+                <ReviewCard key={`${review.author}-${review.title}`} review={review} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <PricingTeaser />
+
+        <section id="faq" className="py-20 px-4 sm:px-6 lg:px-8">
+          <div className="max-w-5xl mx-auto">
+            <div className="text-center mb-8">
+              <h2 className="text-3xl md:text-4xl mb-4">Frequently asked questions</h2>
+              <p className="text-lg text-gray-400">
+                The short version of what collectors usually want to know before they install.
+              </p>
+            </div>
+
+            <div className="rounded-2xl border border-[#333333] overflow-hidden bg-[#0F0F0F]">
+              {config.faqs.map((item) => (
+                <details key={item.q} className="group border-b border-[#333333] last:border-b-0">
+                  <summary className="list-none cursor-pointer px-6 md:px-8 py-5 md:py-6 flex items-center justify-between gap-6 hover:bg-[#121212]">
+                    <span className="text-base md:text-lg">{item.q}</span>
+                    <ChevronDown className="w-5 h-5 text-gray-400 transition-transform group-open:rotate-180" />
+                  </summary>
+                  <div className="px-6 md:px-8 pb-6 -mt-2 text-gray-400 text-sm md:text-base leading-relaxed">
+                    {item.a}
+                  </div>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="download" className="py-20 px-4 sm:px-6 lg:px-8">
+          <div className="max-w-5xl mx-auto text-center rounded-3xl border border-[#333333] bg-[#111111] p-8 md:p-12">
+            <h2 className="text-3xl md:text-4xl leading-tight mb-4">
+              {config.cta.title}
+            </h2>
+            <p className="text-lg text-gray-400 mb-8 max-w-3xl mx-auto leading-relaxed">
+              {config.cta.description}
+            </p>
+
+            <div className="flex justify-center mb-4">
+              <AppStoreBadgeLink width={180} height={60} />
+            </div>
+
+            {config.cta.note ? (
+              <p className="text-sm text-gray-500">{config.cta.note}</p>
+            ) : null}
+          </div>
+        </section>
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import Image from "next/image";
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { Star, Check, Images, BookOpen, ChevronDown, Instagram, Twitter, Facebook, Camera, MapPin, Share2, Wine, Sparkles } from "lucide-react";
+import { Star, Check, Images, BookOpen, ChevronDown, Camera, MapPin, Share2, Wine, Sparkles } from "lucide-react";
+import AppStoreBadgeLink from "@/components/AppStoreBadgeLink";
+import AppStoreRatingLink from "@/components/AppStoreRatingLink";
 import { ImageWithFallback } from "@/components/figma/ImageWithFallback";
 import HeroVideo from "@/components/HeroVideo";
+import SiteFooter from "@/components/SiteFooter";
+import SiteHeader from "@/components/SiteHeader";
 import StoryVideo from "@/components/StoryVideo";
 import {
-  APP_STORE_RATING_COUNT,
   APP_STORE_URL,
 } from "@/lib/app-store";
 
@@ -184,45 +186,7 @@ export default function LandingPage() {
 
   return (
     <div className="min-h-screen bg-[#0A0A0A] text-white">
-      {/* Header */}
-      <header className="fixed top-0 left-0 right-0 z-50 bg-[#0A0A0A]/95 backdrop-blur-md border-b border-[#333333]">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-3 md:py-4">
-            <div className="relative flex items-center overflow-visible">
-              <div className="h-8 md:h-10 lg:h-12">
-                <Image
-                  src="/BarrelBook%20Logo%20Large.png"
-                  alt="BarrelBook logo"
-                  width={280}
-                  height={96}
-                  className="h-full w-auto origin-left scale-[1.125]"
-                  priority
-                />
-              </div>
-            </div>
-            <nav className="hidden md:flex items-center gap-8">
-              <a href="#how-it-works" className="text-gray-300 hover:text-white transition-colors">How it works</a>
-              <a href="#pricing" className="text-gray-300 hover:text-white transition-colors">Pricing</a>
-              <a href="#download" className="text-gray-300 hover:text-white transition-colors">Download</a>
-            </nav>
-            <a
-              href="https://apps.apple.com/us/app/barrelbook-whiskey-catalog/id6751737898"
-              aria-label="Download on the App Store"
-              className="inline-flex items-center"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Image
-                src="/badges/app-store.svg"
-                alt="Download on the App Store"
-                width={140}
-                height={46}
-                className="h-9 w-auto"
-              />
-            </a>
-          </div>
-        </div>
-      </header>
+      <SiteHeader />
 
       {/* Hero Section */}
       <section className="pt-28 pb-12 px-4 sm:px-6 lg:px-8">
@@ -244,33 +208,10 @@ export default function LandingPage() {
               </p>
 
               {/* WEB-005: Social proof from the current App Store listing. */}
-              <a
-                href={APP_STORE_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`Read ${APP_STORE_RATING_COUNT} five-star App Store reviews`}
-                className="inline-flex items-center gap-2 mb-6 text-sm text-gray-300 hover:text-white transition-colors"
-              >
-                <span className="flex" aria-hidden="true">
-                  {[0, 1, 2, 3, 4].map((i) => (
-                    <Star key={i} className="w-4 h-4 text-[#D2691E] fill-current" />
-                  ))}
-                </span>
-                <span>
-                  <span className="font-semibold text-white">{APP_STORE_RATING_COUNT}</span> five-star ratings on the App Store
-                </span>
-              </a>
+              <AppStoreRatingLink className="inline-flex items-center gap-2 mb-6 text-sm text-gray-300 hover:text-white transition-colors" />
 
               <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start items-center mb-6">
-                <a
-                  href={APP_STORE_URL}
-                  aria-label="Download on the App Store"
-                  className="inline-block"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Image src="/badges/app-store.svg" alt="Download on the App Store" width={180} height={60} priority />
-                </a>
+                <AppStoreBadgeLink width={180} height={60} priority />
               </div>
 
               <div className="flex flex-wrap items-center justify-center lg:justify-start gap-3 text-sm text-gray-400">
@@ -623,80 +564,14 @@ export default function LandingPage() {
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8 items-center">
-              <a
-                href={APP_STORE_URL}
-                aria-label="Download on the App Store"
-                className="inline-block"
-                target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Image src="/badges/app-store.svg" alt="Download on the App Store" width={180} height={60} />
-            </a>
+            <AppStoreBadgeLink width={180} height={60} />
           </div>
 
           <p className="text-sm text-gray-500">Available on iPhone and iPad today. Android is on the roadmap.</p>
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="py-12 px-4 sm:px-6 lg:px-8 bg-[#1A1A1A] border-t border-[#333333]">
-        <div className="max-w-7xl mx-auto">
-          <div className="flex flex-col md:flex-row justify-between items-center">
-            <div className="relative flex items-center mb-4 md:mb-0 overflow-visible">
-              <div className="h-8 md:h-10 lg:h-12">
-                <Image
-                  src="/BarrelBook%20Logo%20Large.png"
-                  alt="BarrelBook logo"
-                  width={280}
-                  height={96}
-                  className="h-full w-auto origin-left scale-[1.125]"
-                />
-              </div>
-            </div>
-
-            <div className="flex gap-6 text-sm text-gray-400">
-              <a href="/privacy" className="hover:text-white transition-colors">Privacy Policy</a>
-              <a href="/terms" className="hover:text-white transition-colors">Terms of Service</a>
-            </div>
-          </div>
-
-          <div className="flex justify-center md:justify-end mt-6">
-            <div className="flex items-center gap-5 text-gray-400">
-              <a
-                href="https://www.instagram.com/barrelbook_app/"
-                aria-label="Instagram"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-white"
-              >
-                <Instagram className="w-5 h-5" />
-              </a>
-              <a
-                href="https://x.com/barrelbook_app"
-                aria-label="X (Twitter)"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-white"
-              >
-                <Twitter className="w-5 h-5" />
-              </a>
-              <a
-                href="https://www.facebook.com/share/19tKbWea4A/?mibextid=wwXIfr"
-                aria-label="Facebook"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:text-white"
-              >
-                <Facebook className="w-5 h-5" />
-              </a>
-            </div>
-          </div>
-
-          <div className="border-t border-[#333333] mt-8 pt-8 text-center text-gray-400 text-sm">
-            <p>© 2025–{new Date().getFullYear()} BarrelBook. All rights reserved.</p>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 }

--- a/src/components/PricingTeaser.tsx
+++ b/src/components/PricingTeaser.tsx
@@ -1,0 +1,71 @@
+import AppStoreBadgeLink from "@/components/AppStoreBadgeLink";
+
+const PLANS = [
+  {
+    name: "Free",
+    price: "Free",
+    detail: "10 bottles",
+    description: "Start scanning and organizing your shelf with no credit card required.",
+  },
+  {
+    name: "Plus",
+    price: "$49/yr",
+    detail: "100 bottles",
+    description: "More room for a growing collection, plus enhanced recognition and pricing data.",
+  },
+  {
+    name: "Pro",
+    price: "$99/yr",
+    detail: "Unlimited bottles",
+    description: "For serious shelves that need the strongest recognition and the most headroom.",
+  },
+] as const;
+
+export default function PricingTeaser() {
+  return (
+    <section id="pricing" className="py-20 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-7xl mx-auto">
+        <div className="max-w-4xl mx-auto text-center mb-10">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-[#D2691E] mb-4">
+            Pricing
+          </p>
+          <h2 className="text-3xl md:text-4xl leading-tight mb-4">
+            Free to start. Upgrade when your shelf grows.
+          </h2>
+          <p className="text-lg text-gray-400 leading-relaxed">
+            Start with 10 bottles for free. Move to Plus at $49/year or Pro at $99/year when you need more space and more power.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {PLANS.map((plan) => (
+            <div
+              key={plan.name}
+              className={`rounded-2xl border p-6 ${
+                plan.name === "Pro"
+                  ? "border-[#D2691E] bg-gradient-to-br from-[#D2691E]/15 to-[#0A0A0A]"
+                  : "border-[#333333] bg-[#111111]"
+              }`}
+            >
+              <p className="text-sm font-semibold uppercase tracking-[0.22em] text-gray-400 mb-4">
+                {plan.name}
+              </p>
+              <div className="mb-4">
+                <p className="text-3xl text-white mb-1">{plan.price}</p>
+                <p className="text-sm text-[#D2691E]">{plan.detail}</p>
+              </div>
+              <p className="text-sm text-gray-300 leading-relaxed">{plan.description}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 flex flex-col items-center gap-3 text-center">
+          <AppStoreBadgeLink width={180} height={60} />
+          <p className="text-sm text-gray-500">
+            Available on iPhone and iPad. Android is on the roadmap.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -1,0 +1,45 @@
+import { Star } from "lucide-react";
+
+export type ReviewCardData = {
+  title: string;
+  text: string;
+  author: string;
+  date: string;
+  version: string;
+};
+
+type ReviewCardProps = {
+  review: ReviewCardData;
+  featured?: boolean;
+  className?: string;
+};
+
+export default function ReviewCard({
+  review,
+  featured = false,
+  className = "",
+}: ReviewCardProps) {
+  return (
+    <div
+      className={`border border-[#333333] bg-[#0A0A0A] flex flex-col ${
+        featured ? "rounded-2xl p-8" : "rounded-xl p-6"
+      } ${className}`.trim()}
+    >
+      <div className="flex mb-3">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <Star key={i} className="w-4 h-4 text-[#D2691E] fill-current" />
+        ))}
+      </div>
+      <h3 className={`text-white font-semibold mb-2 ${featured ? "text-lg" : "text-base"}`}>
+        {review.title}
+      </h3>
+      <p className={`text-gray-300 flex-1 ${featured ? "text-base leading-relaxed" : "text-base"}`}>
+        {review.text}
+      </p>
+      <div className="flex items-center justify-between gap-4 text-xs text-gray-500 mt-5">
+        <span>{review.author}</span>
+        <span>{review.date} · v{review.version}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SiteFooter.tsx
+++ b/src/components/SiteFooter.tsx
@@ -1,0 +1,65 @@
+import Image from "next/image";
+import { Facebook, Instagram, Twitter } from "lucide-react";
+
+export default function SiteFooter() {
+  return (
+    <footer className="py-12 px-4 sm:px-6 lg:px-8 bg-[#1A1A1A] border-t border-[#333333]">
+      <div className="max-w-7xl mx-auto">
+        <div className="flex flex-col md:flex-row justify-between items-center">
+          <div className="relative flex items-center mb-4 md:mb-0 overflow-visible">
+            <div className="h-8 md:h-10 lg:h-12">
+              <Image
+                src="/BarrelBook%20Logo%20Large.png"
+                alt="BarrelBook logo"
+                width={280}
+                height={96}
+                className="h-full w-auto origin-left scale-[1.125]"
+              />
+            </div>
+          </div>
+
+          <div className="flex gap-6 text-sm text-gray-400">
+            <a href="/privacy" className="hover:text-white transition-colors">Privacy Policy</a>
+            <a href="/terms" className="hover:text-white transition-colors">Terms of Service</a>
+          </div>
+        </div>
+
+        <div className="flex justify-center md:justify-end mt-6">
+          <div className="flex items-center gap-5 text-gray-400">
+            <a
+              href="https://www.instagram.com/barrelbook_app/"
+              aria-label="Instagram"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white"
+            >
+              <Instagram className="w-5 h-5" />
+            </a>
+            <a
+              href="https://x.com/barrelbook_app"
+              aria-label="X (Twitter)"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white"
+            >
+              <Twitter className="w-5 h-5" />
+            </a>
+            <a
+              href="https://www.facebook.com/share/19tKbWea4A/?mibextid=wwXIfr"
+              aria-label="Facebook"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-white"
+            >
+              <Facebook className="w-5 h-5" />
+            </a>
+          </div>
+        </div>
+
+        <div className="border-t border-[#333333] mt-8 pt-8 text-center text-gray-400 text-sm">
+          <p>© 2025–{new Date().getFullYear()} BarrelBook. All rights reserved.</p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,58 @@
+import Image from "next/image";
+import AppStoreBadgeLink from "@/components/AppStoreBadgeLink";
+
+export type SiteHeaderNavItem = {
+  href: string;
+  label: string;
+};
+
+const DEFAULT_NAV_ITEMS: SiteHeaderNavItem[] = [
+  { href: "#how-it-works", label: "How it works" },
+  { href: "#pricing", label: "Pricing" },
+  { href: "#download", label: "Download" },
+];
+
+type SiteHeaderProps = {
+  navItems?: SiteHeaderNavItem[];
+};
+
+export default function SiteHeader({
+  navItems = DEFAULT_NAV_ITEMS,
+}: SiteHeaderProps) {
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 bg-[#0A0A0A]/95 backdrop-blur-md border-b border-[#333333]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between py-3 md:py-4">
+          <div className="relative flex items-center overflow-visible">
+            <div className="h-8 md:h-10 lg:h-12">
+              <Image
+                src="/BarrelBook%20Logo%20Large.png"
+                alt="BarrelBook logo"
+                width={280}
+                height={96}
+                className="h-full w-auto origin-left scale-[1.125]"
+                priority
+              />
+            </div>
+          </div>
+
+          <nav className="hidden md:flex items-center gap-8">
+            {navItems.map((item) => (
+              <a key={item.href} href={item.href} className="text-gray-300 hover:text-white transition-colors">
+                {item.label}
+              </a>
+            ))}
+          </nav>
+
+          <AppStoreBadgeLink
+            className="inline-flex items-center"
+            width={140}
+            height={46}
+            imageClassName="h-9 w-auto"
+            priority
+          />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/apple-app-site-association.ts
+++ b/src/lib/apple-app-site-association.ts
@@ -8,6 +8,21 @@ const GOLDEN_TICKET_PATH_COMPONENT = {
   comment: "Canonical BarrelBook Golden Ticket links",
 } as const;
 
+const SCAN_PATH_COMPONENT = {
+  "/": "/scan",
+  comment: "Universal link handoff to the BarrelBook scan experience",
+} as const;
+
+const COLLECTION_PATH_COMPONENT = {
+  "/": "/collection",
+  comment: "Universal link handoff to the BarrelBook collection experience",
+} as const;
+
+const STORE_PICKS_PATH_COMPONENT = {
+  "/": "/store-picks",
+  comment: "Universal link handoff to the BarrelBook store-picks experience",
+} as const;
+
 export const AASA_RESPONSE_HEADERS = {
   "Cache-Control": "public, max-age=300, s-maxage=300",
   "Content-Type": "application/json; charset=utf-8",
@@ -29,7 +44,13 @@ export function getAppleAppSiteAssociation() {
       details: [
         {
           appIDs: getConfiguredAppIds(),
-          components: [PROMO_PATH_COMPONENT, GOLDEN_TICKET_PATH_COMPONENT],
+          components: [
+            SCAN_PATH_COMPONENT,
+            COLLECTION_PATH_COMPONENT,
+            STORE_PICKS_PATH_COMPONENT,
+            PROMO_PATH_COMPONENT,
+            GOLDEN_TICKET_PATH_COMPONENT,
+          ],
         },
       ],
     },

--- a/src/lib/deep-link-landing-pages.ts
+++ b/src/lib/deep-link-landing-pages.ts
@@ -1,0 +1,461 @@
+import type { Metadata } from "next";
+import type { ReviewCardData } from "@/components/ReviewCard";
+
+type ScreenshotConfig = {
+  src: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  className?: string;
+  hideOnMobile?: boolean;
+};
+
+type VideoHeroMedia = {
+  kind: "video";
+  src: string;
+  poster: string;
+  ariaLabel: string;
+  width?: number;
+  height?: number;
+  className?: string;
+};
+
+type ScreenshotHeroMedia = {
+  kind: "screenshots";
+  screenshots: ScreenshotConfig[];
+};
+
+type HeroMedia = VideoHeroMedia | ScreenshotHeroMedia;
+
+type StripItem = {
+  title: string;
+  description: string;
+};
+
+type LandingPageConfig = {
+  slug: "scan" | "collection" | "store-picks";
+  path: "/scan" | "/collection" | "/store-picks";
+  metadata: Metadata;
+  hero: {
+    eyebrow: string;
+    title: string;
+    description: string;
+    media: HeroMedia;
+  };
+  proof: {
+    eyebrow: string;
+    title: string;
+    bullets: string[];
+    review: ReviewCardData;
+  };
+  strip: {
+    id: "how-it-works";
+    eyebrow: string;
+    title: string;
+    description: string;
+    variant: "steps" | "capabilities";
+    media: ScreenshotConfig[];
+    items: StripItem[];
+  };
+  reviews: {
+    eyebrow: string;
+    title: string;
+    description: string;
+    items: ReviewCardData[];
+  };
+  faqs: Array<{
+    q: string;
+    a: string;
+  }>;
+  cta: {
+    title: string;
+    description: string;
+    note?: string;
+  };
+};
+
+const REVIEWS = {
+  scanFeatured: {
+    title: "The first app that actually handles store picks",
+    text: "I've tried other whiskey apps and none of them handle store picks or barrel selections well. BarrelBook nails it—scans the label, picks up the barrel number, batch info, and even the store name. Finally an app built for how bourbon actually works.",
+    author: "Aurelius3000",
+    date: "Dec 20, 2025",
+    version: "1.1",
+  },
+  scanSupportOne: {
+    title: "Best Bourbon tracking App",
+    text: "BarrelBook has rapidly become one of my favorite apps. The ability to scan labels and instantly catalog bottles is a game changer. Tracking prices, locations, and personal notes makes managing a collection effortless. Highly recommend for any bourbon enthusiast!",
+    author: "MrWCBrown",
+    date: "Feb 4, 2026",
+    version: "1.3",
+  },
+  scanSupportTwo: {
+    title: "Best app for Bourbon Inventory",
+    text: "Simple and easy to use. Snap a photo and your bourbon is added to your collection! Gives MSRP, secondary market prices, proof and so much more. If you want to keep track of your collection, this is the one.",
+    author: "RD24/7$",
+    date: "Jan 25, 2026",
+    version: "1.2",
+  },
+  collectionFeatured: {
+    title: "Excel not Needed",
+    text: "Finally, no more spreadsheets! BarrelBook scans your bottles and tracks everything—prices, proof, barrel numbers—all in one clean app. A must-have for bourbon collectors.",
+    author: "AtlantaUnited17",
+    date: "Feb 1, 2026",
+    version: "1.3",
+  },
+  collectionSupportOne: {
+    title: "Great App for Bottle Inventory, Pricing, and Accuracy!",
+    text: "Incredibly easy to use. The AI captures detailed bottle info from photos accurately. Market pricing data is a fantastic bonus. Clean interface makes managing a growing collection effortless.",
+    author: "WallyWorld34",
+    date: "Feb 4, 2026",
+    version: "1.3",
+  },
+  collectionSupportTwo: {
+    title: "An interesting concept that works great!",
+    text: "I love the idea of this app as it lets you keep track of what you have. What I thought was cool is that you could see how much bottles are worth on the secondary market compared to what I paid at MSRP. Highly recommend!",
+    author: "Drbourbondvm",
+    date: "Feb 1, 2026",
+    version: "1.3",
+  },
+} as const;
+
+export const scanLandingPageConfig: LandingPageConfig = {
+  slug: "scan",
+  path: "/scan",
+  metadata: {
+    title: "Scan bourbon bottles in seconds",
+    description:
+      "Use BarrelBook to scan bourbon and whiskey labels, capture store picks, barrel numbers, proof, and batch details without typing.",
+    alternates: {
+      canonical: "/scan",
+    },
+    openGraph: {
+      title: "Scan bourbon bottles in seconds",
+      description:
+        "Snap up to three bottle photos and let BarrelBook capture the proof, batch, store pick, and barrel number for you.",
+      url: "https://www.barrelbook.app/scan",
+    },
+    twitter: {
+      title: "Scan bourbon bottles in seconds",
+      description:
+        "Snap up to three bottle photos and let BarrelBook capture the proof, batch, store pick, and barrel number for you.",
+    },
+  },
+  hero: {
+    eyebrow: "Whiskey bottle scanner",
+    title: "Scan bourbon bottles in seconds.",
+    description:
+      "Snap up to three photos. BarrelBook captures the proof, batch, store pick, and barrel number straight from the label. No barcodes, no typing, no spreadsheet cleanup.",
+    media: {
+      kind: "video",
+      src: "/videos/bottle-scanning.mp4",
+      poster: "/video-posters/bottle-scanning.jpg",
+      ariaLabel: "Scanning a bourbon bottle label with the BarrelBook app",
+      width: 886,
+      height: 1920,
+      className: "w-full max-w-[240px] sm:max-w-[280px] lg:max-w-[300px]",
+    },
+  },
+  proof: {
+    eyebrow: "Why it works",
+    title: "Built for bottles that deserve more than a barcode.",
+    bullets: [
+      "Captures store name, barrel number, batch, proof, and other collector-grade label details.",
+      "Supports up to three photos per bottle when front labels and back labels both matter.",
+      "Faster than manual entry in Notes, Airtable, or a spreadsheet you never want to touch again.",
+    ],
+    review: REVIEWS.scanFeatured,
+  },
+  strip: {
+    id: "how-it-works",
+    eyebrow: "How it works",
+    title: "Snap, review, save.",
+    description:
+      "Turn a few bottle photos into a clean, editable record you can search later when you are at the store, at a tasting, or standing in front of your shelf.",
+    variant: "steps",
+    media: [
+      {
+        src: "/App%20Scan%20WLW.png",
+        alt: "Scanning the front label of a William Larue Weller bottle in BarrelBook",
+      },
+      {
+        src: "/App%20Scan%20WLW3.png",
+        alt: "Reviewing BarrelBook's extracted bottle details after scanning",
+      },
+      {
+        src: "/App%20Scan%20WLW4.png",
+        alt: "Saving a scanned bourbon bottle record inside BarrelBook",
+      },
+    ],
+    items: [
+      {
+        title: "Snap the label",
+        description: "Take up to three photos so BarrelBook can see the front label, back label, and any tricky barrel or batch text.",
+      },
+      {
+        title: "Review the details",
+        description: "Check the extracted proof, batch, store-pick, and bottle data before it hits your shelf.",
+      },
+      {
+        title: "Save it to your collection",
+        description: "Keep the cleaned-up record with the rest of your bottles, ready to search, edit, or share later.",
+      },
+    ],
+  },
+  reviews: {
+    eyebrow: "Collector proof",
+    title: "Real collectors use it because scanning has to hold up in the messy cases.",
+    description:
+      "These are the reviews that matter for scanning: fast capture, clean records, and bottle details that generic whiskey apps usually skip.",
+    items: [REVIEWS.scanSupportOne, REVIEWS.scanSupportTwo],
+  },
+  faqs: [
+    {
+      q: "How does AI recognition work?",
+      a: "Open BarrelBook, take up to three bottle photos, and the app reads the label text to prefill the record. Multi-angle photos help when a bottle has meaningful detail on the back label or in smaller print.",
+    },
+    {
+      q: "What information can it capture?",
+      a: "Typical fields include the producer, expression, proof, batch or barrel identifiers, store-pick details, pricing, and other label micro-text that collectors care about.",
+    },
+    {
+      q: "Does it work for store picks and private barrels?",
+      a: "Yes. BarrelBook is specifically useful for store picks, barrel selections, and other collector bottles where the details are not just a UPC code and a bottle name.",
+    },
+  ],
+  cta: {
+    title: "Download BarrelBook and scan your next bottle.",
+    description:
+      "If the bottle is worth buying, it is worth capturing cleanly. BarrelBook keeps that work fast.",
+    note: "Available on iPhone and iPad today. Android is on the roadmap.",
+  },
+};
+
+export const collectionLandingPageConfig: LandingPageConfig = {
+  slug: "collection",
+  path: "/collection",
+  metadata: {
+    title: "Track your bourbon collection without spreadsheets",
+    description:
+      "Use BarrelBook to catalog bottles, search your shelf, track proof, batch, notes, fill level, and pricing from your iPhone.",
+    alternates: {
+      canonical: "/collection",
+    },
+    openGraph: {
+      title: "Track your bourbon collection without spreadsheets",
+      description:
+        "Keep your bourbon collection in your pocket with a searchable library for bottles, batches, pricing, notes, and shelf details.",
+      url: "https://www.barrelbook.app/collection",
+    },
+    twitter: {
+      title: "Track your bourbon collection without spreadsheets",
+      description:
+        "Keep your bourbon collection in your pocket with a searchable library for bottles, batches, pricing, notes, and shelf details.",
+    },
+  },
+  hero: {
+    eyebrow: "Bourbon collection app",
+    title: "Track your bourbon collection without spreadsheets.",
+    description:
+      "Catalog bottles, search your shelf, and keep your collection in your pocket. Track proof, batch, store, fill level, pricing, and personal notes in one place.",
+    media: {
+      kind: "screenshots",
+      screenshots: [
+        {
+          src: "/Catalog1.png",
+          alt: "Browsing a BarrelBook collection catalog on iPhone",
+          className: "w-full max-w-[250px] sm:max-w-[270px]",
+        },
+        {
+          src: "/App%20Scan%20Blantons2.png",
+          alt: "Viewing a bottle detail screen inside BarrelBook",
+          className: "w-full max-w-[210px] sm:max-w-[230px] translate-y-8",
+          hideOnMobile: true,
+        },
+      ],
+    },
+  },
+  proof: {
+    eyebrow: "Why collectors switch",
+    title: "One portable source of truth for your shelf.",
+    bullets: [
+      "Search a collection by bottle, batch, proof, store, tags, and the details you actually use when you are deciding what to buy or open.",
+      "Carry your shelf with you at the store, at tastings, at bars, or when a friend asks what you already own.",
+      "Replace the spreadsheet, the notes app, and the half-kept bottle list with one clean collection record.",
+    ],
+    review: REVIEWS.collectionFeatured,
+  },
+  strip: {
+    id: "how-it-works",
+    eyebrow: "Built for your shelf",
+    title: "Your collection goes wherever you go.",
+    description:
+      "Keep bottle photos and details with you at the store, at tastings, at bars, or with friends. BarrelBook gives you a portable digital shelf, so you always know what you own and what is worth opening, buying, or sharing.",
+    variant: "capabilities",
+    media: [
+      {
+        src: "/Catalog1.png",
+        alt: "Scrolling through a searchable bottle catalog in BarrelBook",
+      },
+      {
+        src: "/App%20Scan%20Blantons2.png",
+        alt: "Viewing bottle details and notes inside BarrelBook",
+      },
+    ],
+    items: [
+      {
+        title: "Search and sort your shelf",
+        description: "Find bottles by proof, batch, producer, store, or tags instead of remembering which spreadsheet tab you used last time.",
+      },
+      {
+        title: "Track what matters per bottle",
+        description: "Keep notes, ratings, fill level, pricing, and collector details together so each bottle has context, not just a name.",
+      },
+      {
+        title: "Keep it with you",
+        description: "Your collection stays in your pocket when you are shopping, planning a tasting, or checking whether a friend already poured that bottle.",
+      },
+    ],
+  },
+  reviews: {
+    eyebrow: "Collection proof",
+    title: "The collection use case is where BarrelBook has to earn its keep.",
+    description:
+      "These reviews speak to the day-to-day value of keeping pricing, bottle details, and your shelf history in one clean app.",
+    items: [REVIEWS.collectionSupportOne, REVIEWS.collectionSupportTwo],
+  },
+  faqs: [
+    {
+      q: "What can I track per bottle?",
+      a: "BarrelBook supports bottle details such as proof, batch or barrel identifiers, store, pricing, notes, ratings, fill level, status, and other collector-specific metadata you want close at hand.",
+    },
+    {
+      q: "How many bottles can I track on the Free plan?",
+      a: "The Free plan includes a 10-bottle library. Plus expands that to 100 bottles, and Pro removes the bottle limit entirely.",
+    },
+    {
+      q: "Can I export my collection?",
+      a: "Not yet. Today BarrelBook is focused on giving you a searchable, portable collection on iPhone and iPad, rather than a separate export workflow.",
+    },
+  ],
+  cta: {
+    title: "Put your shelf in your pocket.",
+    description:
+      "Start with the bottles you already own, keep them searchable, and stop rebuilding the same list in three different places.",
+    note: "Available on iPhone and iPad today. Android is on the roadmap.",
+  },
+};
+
+export const storePicksLandingPageConfig: LandingPageConfig = {
+  slug: "store-picks",
+  path: "/store-picks",
+  metadata: {
+    title: "Made for store picks and collector bottles",
+    description:
+      "Track store picks, single barrels, batch details, barrel numbers, warehouse and floor data with BarrelBook's bourbon-first scanner.",
+    alternates: {
+      canonical: "/store-picks",
+    },
+    openGraph: {
+      title: "Made for store picks and collector bottles",
+      description:
+        "Track the details generic whiskey apps miss, including store names, barrel numbers, batch data, warehouse, floor, and mash bill notes.",
+      url: "https://www.barrelbook.app/store-picks",
+    },
+    twitter: {
+      title: "Made for store picks and collector bottles",
+      description:
+        "Track the details generic whiskey apps miss, including store names, barrel numbers, batch data, warehouse, floor, and mash bill notes.",
+    },
+  },
+  hero: {
+    eyebrow: "Store pick tracker",
+    title: "Made for store picks and collector bottles.",
+    description:
+      "Track the details generic whiskey apps miss, including store name, barrel number, batch, warehouse, floor, mash bill, and pricing. BarrelBook is built for the bottles bourbon collectors actually chase.",
+    media: {
+      kind: "video",
+      src: "/videos/bottle-scanning.mp4",
+      poster: "/video-posters/bottle-scanning.jpg",
+      ariaLabel: "Scanning a collector bourbon label with store-pick details in BarrelBook",
+      width: 886,
+      height: 1920,
+      className: "w-full max-w-[240px] sm:max-w-[280px] lg:max-w-[300px]",
+    },
+  },
+  proof: {
+    eyebrow: "Why BarrelBook fits this job",
+    title: "Collector-grade details, not generic whiskey fields.",
+    bullets: [
+      "Captures the store name, barrel number, batch, proof, and bottle-specific details that make one pick different from the next.",
+      "Uses up to three photos per bottle so front-label branding and back-label micro-text both make it into the record.",
+      "Keeps rare picks searchable by store, selection details, and the metadata you actually need when comparing bottles.",
+    ],
+    review: REVIEWS.scanFeatured,
+  },
+  strip: {
+    id: "how-it-works",
+    eyebrow: "Built for bourbon detail",
+    title: "The details bourbon collectors care about stay attached to the bottle.",
+    description:
+      "BarrelBook is especially useful when a bottle has more to remember than a name. Store picks, private barrels, and batch-specific bottles stay searchable because the important details are part of the record, not buried in a note field.",
+    variant: "capabilities",
+    media: [
+      {
+        src: "/App%20Scan%20WLW.png",
+        alt: "Scanning a collector bourbon bottle with store-pick-relevant details in BarrelBook",
+      },
+      {
+        src: "/App%20Scan%20WLW3.png",
+        alt: "Reviewing extracted batch, proof, and label detail fields in BarrelBook",
+      },
+      {
+        src: "/App%20Scan%20WLW4.png",
+        alt: "Saving a detailed bourbon bottle record for a collector bottle in BarrelBook",
+      },
+    ],
+    items: [
+      {
+        title: "Store names and barrel numbers",
+        description: "Keep each pick tied to the store and selection details that make it distinct from the broader release.",
+      },
+      {
+        title: "Batch, warehouse, and floor",
+        description: "Record the bottle metadata collectors actually compare when they are deciding what to buy, trade, or open.",
+      },
+      {
+        title: "Searchable later",
+        description: "Filter your shelf by store-pick details instead of trying to remember which note field held the one fact you care about.",
+      },
+    ],
+  },
+  reviews: {
+    eyebrow: "Collector proof",
+    title: "This page exists because generic whiskey apps usually fall apart on store picks.",
+    description:
+      "These reviews are the strongest evidence that BarrelBook handles bottle-level nuance instead of flattening everything into the same generic record.",
+    items: [REVIEWS.scanSupportOne, REVIEWS.collectionSupportOne],
+  },
+  faqs: [
+    {
+      q: "Does BarrelBook know which store a pick came from?",
+      a: "It is designed to capture and preserve store-pick details when they are present on the label, alongside the rest of the bottle record.",
+    },
+    {
+      q: "Can I track private barrel selections and other collector bottles?",
+      a: "Yes. This is one of BarrelBook's strongest use cases, especially when batch, proof, barrel number, or selection-specific notes matter.",
+    },
+    {
+      q: "Why use this instead of a generic whiskey app?",
+      a: "Because the differences that matter on collector bottles are often the exact details generic apps skip. BarrelBook is designed to make those details part of the record from the start.",
+    },
+  ],
+  cta: {
+    title: "Track your next store pick the right way.",
+    description:
+      "If the barrel number, store, or batch matters, the record should keep it front and center. BarrelBook does that from the first scan.",
+    note: "Available on iPhone and iPad today. Android is on the roadmap.",
+  },
+};
+
+export type { LandingPageConfig, ScreenshotConfig };


### PR DESCRIPTION
## What changed
- add a shared `DeepLinkLandingPage` system for focused acquisition pages
- add `/scan`, `/collection`, and `/store-picks` routes using shared App Store, review, pricing, header, and footer primitives
- extend the existing Apple-app-site-association generator and sitemap for the new deep-link paths
- refactor the homepage to reuse the shared site header/footer and App Store primitives

## Why
Sprint A called for deep-link landing pages that reuse existing homepage assets and constants without rebuilding the site shell separately for each route. This also keeps future landing pages cheaper to add.

## Impact
- new SEO-targeted landing pages for scan, collection, and store-picks intents
- new universal-link path coverage for `/scan`, `/collection`, and `/store-picks`
- no changes to the existing promo or creator page templates

## Validation
- `npm run lint`
- `npm run build`