### PR TITLE
Refresh App Store rating copy

### DIFF
--- a/.claude_tasks/2026-05-30_13-53-10/SUMMARY.md
+++ b/.claude_tasks/2026-05-30_13-53-10/SUMMARY.md
@@ -1,0 +1,28 @@
+# App Store Rating Refresh Summary
+
+## Files Added
+- `.claude_tasks/2026-05-30_13-53-10/T1_update_app_store_rating_copy.md`
+- `.claude_tasks/2026-05-30_13-53-10/T2_push_to_production.md`
+- `.claude_tasks/2026-05-30_13-53-10/SUMMARY.md`
+- `plans/sprints/2026-05-30-app-store-rating-refresh/prd.json`
+- `plans/sprints/2026-05-30-app-store-rating-refresh/progress.txt`
+- `plans/sprints/2026-05-30-app-store-rating-refresh/prompt.md`
+
+## Files Modified
+- `src/lib/app-store.ts`
+- `src/components/AppStoreRatingLink.tsx`
+
+## Overview
+Updated the stale App Store social proof from `24 five-star ratings` to durable
+copy: `4.8 stars from 100+ App Store ratings`. Kept exact App Store values in
+structured data with `ratingValue=4.8` and `reviewCount=116`.
+
+## Verification
+- `npm run build` passed.
+- Generated homepage output contains the updated visible copy.
+- Generated JSON-LD contains the exact rating values.
+
+## Next Steps
+- Push branch.
+- Merge PR to `main`.
+- Confirm Vercel production deployment and live homepage copy.

--- a/.claude_tasks/2026-05-30_13-53-10/T1_update_app_store_rating_copy.md
+++ b/.claude_tasks/2026-05-30_13-53-10/T1_update_app_store_rating_copy.md
@@ -16,3 +16,10 @@ Store-backed rating copy.
 - `npm run build`
 - Confirm rendered homepage text includes `4.8 stars from 100+ App Store ratings`.
 - Confirm JSON-LD includes exact `4.8` and `116` values.
+
+## Result
+- Updated centralized constants in `src/lib/app-store.ts`.
+- Updated `AppStoreRatingLink` text and accessibility label.
+- `npm run build` passed.
+- Generated homepage contains `4.8 stars from 100+ App Store ratings`.
+- Generated JSON-LD contains `ratingValue: 4.8` and `reviewCount: 116`.

--- a/.claude_tasks/2026-05-30_13-53-10/T1_update_app_store_rating_copy.md
+++ b/.claude_tasks/2026-05-30_13-53-10/T1_update_app_store_rating_copy.md
@@ -1,0 +1,18 @@
+# Task 1: Update App Store Rating Copy
+
+## Description
+Replace the stale homepage claim of `24 five-star ratings` with current App
+Store-backed rating copy.
+
+## Current Source
+- Apple listing showed `4.8` from `116 Ratings` on 2026-05-30.
+
+## Decisions
+- Use exact values for structured data: `ratingValue=4.8`, `reviewCount=116`.
+- Use durable marketing copy in the hero: `4.8 stars from 100+ App Store ratings`.
+- Keep the App Store link and existing star visual.
+
+## Verification
+- `npm run build`
+- Confirm rendered homepage text includes `4.8 stars from 100+ App Store ratings`.
+- Confirm JSON-LD includes exact `4.8` and `116` values.

--- a/.claude_tasks/2026-05-30_13-53-10/T2_push_to_production.md
+++ b/.claude_tasks/2026-05-30_13-53-10/T2_push_to_production.md
@@ -1,0 +1,15 @@
+# Task 2: Push To Production
+
+## Description
+Publish the rating-copy hotfix through the normal GitHub PR and Vercel production
+deployment path.
+
+## Decisions
+- Branch: `codex/update-app-store-rating-copy`.
+- Base: current `origin/main`.
+- Use a normal PR merge to `main`; do not deploy a stale branch directly.
+
+## Verification
+- PR check passes.
+- Vercel production deployment for the merge commit is ready.
+- Live homepage contains the updated rating copy.

--- a/plans/sprints/2026-05-30-app-store-rating-refresh/prd.json
+++ b/plans/sprints/2026-05-30-app-store-rating-refresh/prd.json
@@ -1,0 +1,48 @@
+{
+  "project": {
+    "name": "App Store Rating Refresh",
+    "repoRoot": "."
+  },
+  "definitionOfDone": {
+    "required": [
+      "All items pass",
+      "Project builds",
+      "Production homepage no longer shows stale rating copy"
+    ]
+  },
+  "files_changed": [
+    "src/lib/app-store.ts",
+    "src/components/AppStoreRatingLink.tsx",
+    "plans/sprints/2026-05-30-app-store-rating-refresh/prd.json",
+    "plans/sprints/2026-05-30-app-store-rating-refresh/progress.txt",
+    "plans/sprints/2026-05-30-app-store-rating-refresh/prompt.md"
+  ],
+  "items": [
+    {
+      "id": "RATE-001",
+      "priority": 1,
+      "title": "Refresh App Store rating copy",
+      "description": "Update centralized App Store rating constants and the homepage rating link so the hero uses durable current copy while JSON-LD keeps exact App Store values.",
+      "acceptanceCriteria": [
+        "Structured data uses ratingValue 4.8 and reviewCount 116",
+        "Hero rating link says 4.8 stars from 100+ App Store ratings",
+        "App Store link behavior is unchanged"
+      ],
+      "passes": false,
+      "tags": ["copy", "seo", "homepage"]
+    },
+    {
+      "id": "RATE-002",
+      "priority": 1,
+      "title": "Verify and publish",
+      "description": "Build, verify rendered output, push through PR, and confirm production updates.",
+      "acceptanceCriteria": [
+        "npm run build completes successfully",
+        "Rendered homepage text contains the updated rating claim",
+        "Production deployment is ready after merge"
+      ],
+      "passes": false,
+      "tags": ["verification", "production"]
+    }
+  ]
+}

--- a/plans/sprints/2026-05-30-app-store-rating-refresh/prd.json
+++ b/plans/sprints/2026-05-30-app-store-rating-refresh/prd.json
@@ -28,7 +28,7 @@
         "Hero rating link says 4.8 stars from 100+ App Store ratings",
         "App Store link behavior is unchanged"
       ],
-      "passes": false,
+      "passes": true,
       "tags": ["copy", "seo", "homepage"]
     },
     {

--- a/plans/sprints/2026-05-30-app-store-rating-refresh/progress.txt
+++ b/plans/sprints/2026-05-30-app-store-rating-refresh/progress.txt
@@ -2,7 +2,7 @@ App Store Rating Refresh
 =====================================================
 
 Started: 2026-05-30
-Status: In Progress (0/2 items)
+Status: In Progress (1/2 items)
 
 ## Goals
 - Remove stale `24 five-star ratings` homepage copy.
@@ -12,8 +12,13 @@ Status: In Progress (0/2 items)
 ## Items
 
 ### Priority 1
-- [ ] RATE-001: Refresh App Store rating copy
+- [x] RATE-001: Refresh App Store rating copy
 - [ ] RATE-002: Verify and publish
+
+## Verification Notes
+- `npm run build` passed.
+- Local build output includes `4.8 stars from 100+ App Store ratings`.
+- JSON-LD includes exact `ratingValue=4.8` and `reviewCount=116`.
 
 ## Files to Modify
 - src/lib/app-store.ts

--- a/plans/sprints/2026-05-30-app-store-rating-refresh/progress.txt
+++ b/plans/sprints/2026-05-30-app-store-rating-refresh/progress.txt
@@ -1,0 +1,37 @@
+App Store Rating Refresh
+=====================================================
+
+Started: 2026-05-30
+Status: In Progress (0/2 items)
+
+## Goals
+- Remove stale `24 five-star ratings` homepage copy.
+- Show durable, current App Store social proof.
+- Keep JSON-LD exact for SEO consumers.
+
+## Items
+
+### Priority 1
+- [ ] RATE-001: Refresh App Store rating copy
+- [ ] RATE-002: Verify and publish
+
+## Files to Modify
+- src/lib/app-store.ts
+- src/components/AppStoreRatingLink.tsx
+- plans/sprints/2026-05-30-app-store-rating-refresh/prd.json
+- plans/sprints/2026-05-30-app-store-rating-refresh/progress.txt
+- plans/sprints/2026-05-30-app-store-rating-refresh/prompt.md
+
+## Deployment
+- Publish through GitHub PR merge to main.
+- Let Vercel deploy production from the merge commit.
+
+## Ralph Launch Commands
+
+```bash
+# Iterative (runs up to 25 iterations until all items pass):
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph.sh plans/sprints/2026-05-30-app-store-rating-refresh 25
+
+# Single iteration:
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph_once.sh plans/sprints/2026-05-30-app-store-rating-refresh
+```

--- a/plans/sprints/2026-05-30-app-store-rating-refresh/prompt.md
+++ b/plans/sprints/2026-05-30-app-store-rating-refresh/prompt.md
@@ -1,0 +1,25 @@
+# App Store Rating Refresh Sprint Prompt
+
+Update the stale homepage rating claim using the current App Store listing.
+
+## Current Truth
+
+- App Store listing showed `4.8` from `116 Ratings` on 2026-05-30.
+- Existing website copy says `24 five-star ratings on the App Store`.
+
+## Implementation Constraints
+
+- Keep the App Store URL unchanged.
+- Keep the star visual.
+- Use exact values for structured data: `4.8` and `116`.
+- Use durable public copy: `4.8 stars from 100+ App Store ratings`.
+- Do not redesign the hero or reviews section.
+
+## Verification Commands
+
+```bash
+npm run build
+
+# After build/dev render, confirm generated output includes updated copy.
+rg "4.8 stars from 100\\+ App Store ratings|reviewCount.*116|ratingValue.*4.8" .next src
+```

--- a/src/components/AppStoreRatingLink.tsx
+++ b/src/components/AppStoreRatingLink.tsx
@@ -1,5 +1,9 @@
 import { Star } from "lucide-react";
-import { APP_STORE_RATING_COUNT, APP_STORE_URL } from "@/lib/app-store";
+import {
+  APP_STORE_RATING_DISPLAY_COUNT,
+  APP_STORE_RATING_VALUE,
+  APP_STORE_URL,
+} from "@/lib/app-store";
 
 type AppStoreRatingLinkProps = {
   className?: string;
@@ -13,7 +17,7 @@ export default function AppStoreRatingLink({
       href={APP_STORE_URL}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={`Read ${APP_STORE_RATING_COUNT} five-star App Store reviews`}
+      aria-label={`Read App Store reviews for BarrelBook, rated ${APP_STORE_RATING_VALUE} stars from ${APP_STORE_RATING_DISPLAY_COUNT} ratings`}
       className={className}
     >
       <span className="flex" aria-hidden="true">
@@ -22,7 +26,8 @@ export default function AppStoreRatingLink({
         ))}
       </span>
       <span>
-        <span className="font-semibold text-white">{APP_STORE_RATING_COUNT}</span> five-star ratings on the App Store
+        <span className="font-semibold text-white">{APP_STORE_RATING_VALUE}</span> stars from{" "}
+        <span className="font-semibold text-white">{APP_STORE_RATING_DISPLAY_COUNT}</span> App Store ratings
       </span>
     </a>
   );

--- a/src/lib/app-store.ts
+++ b/src/lib/app-store.ts
@@ -3,8 +3,9 @@ export const APP_STORE_APP_ID = "6751737898";
 export const APP_STORE_URL =
   `https://apps.apple.com/us/app/barrelbook-whiskey-catalog/id${APP_STORE_APP_ID}`;
 
-export const APP_STORE_RATING_VALUE = "5.0";
-export const APP_STORE_RATING_COUNT = "24";
+export const APP_STORE_RATING_VALUE = "4.8";
+export const APP_STORE_RATING_COUNT = "116";
+export const APP_STORE_RATING_DISPLAY_COUNT = "100+";
 
 export const TESTFLIGHT_URL =
   process.env.BARRELBOOK_TESTFLIGHT_URL?.trim() || "https://testflight.apple.com/";


### PR DESCRIPTION
## Summary
- Update stale homepage social proof from `24 five-star ratings` to `4.8 stars from 100+ App Store ratings`.
- Update centralized App Store rating constants to exact current values: `4.8` and `116`.
- Preserve the existing App Store link and hero star visual.

## Why
The App Store listing now shows 4.8 from 116 ratings, so the old `24 five-star ratings` claim was stale and too brittle.

## Verification
- `npm run build`
- Generated homepage output includes `4.8 stars from 100+ App Store ratings`.
- Generated JSON-LD includes `ratingValue: 4.8` and `reviewCount: 116`.
