### PR TITLE
Add new App Store reviews

### DIFF
--- a/.claude_tasks/2026-05-30_13-59-30/SUMMARY.md
+++ b/.claude_tasks/2026-05-30_13-59-30/SUMMARY.md
@@ -1,0 +1,29 @@
+# Add New App Store Reviews Summary
+
+## Files Added
+- `.claude_tasks/2026-05-30_13-59-30/T1_add_new_app_store_reviews.md`
+- `.claude_tasks/2026-05-30_13-59-30/T2_publish_new_reviews.md`
+- `.claude_tasks/2026-05-30_13-59-30/SUMMARY.md`
+- `plans/sprints/2026-05-30-add-new-app-store-reviews/prd.json`
+- `plans/sprints/2026-05-30-add-new-app-store-reviews/progress.txt`
+- `plans/sprints/2026-05-30-add-new-app-store-reviews/prompt.md`
+
+## Files Modified
+- `src/components/LandingPage.tsx`
+
+## Overview
+Added two newer App Store reviews to the homepage review grid:
+- `This app makes my hobby more organized.` by `Cewj2000`
+- `Great app so far` by `BigJ71141`
+
+The existing review card design, five-star visual, and App Store CTAs were left
+unchanged.
+
+## Verification
+- `npm run build` passed.
+- Generated homepage output contains both new titles and authors.
+
+## Next Steps
+- Push branch.
+- Merge PR to `main`.
+- Confirm Vercel production deployment and live homepage copy.

--- a/.claude_tasks/2026-05-30_13-59-30/T1_add_new_app_store_reviews.md
+++ b/.claude_tasks/2026-05-30_13-59-30/T1_add_new_app_store_reviews.md
@@ -16,3 +16,9 @@ Add two newer App Store reviews supplied by the user to the homepage review grid
 ## Verification
 - `npm run build`
 - Confirm rendered homepage output contains both new titles and authors.
+
+## Result
+- Added both reviews to the homepage review grid near the front of the list.
+- Kept the existing review card layout and five-star visual.
+- `npm run build` passed.
+- Generated homepage output contains both new titles and authors.

--- a/.claude_tasks/2026-05-30_13-59-30/T1_add_new_app_store_reviews.md
+++ b/.claude_tasks/2026-05-30_13-59-30/T1_add_new_app_store_reviews.md
@@ -1,0 +1,18 @@
+# Task 1: Add New App Store Reviews
+
+## Description
+Add two newer App Store reviews supplied by the user to the homepage review grid.
+
+## Reviews
+- `This app makes my hobby more organized.` by `Cewj2000`, dated `May 19`.
+- `Great app so far` by `BigJ71141`, dated `May 18`.
+
+## Decisions
+- Add both reviews near the front of the homepage review list so current social
+  proof appears first.
+- Keep the existing review card design and five-star visual.
+- Do not redesign the reviews section or alter pricing/CTA behavior.
+
+## Verification
+- `npm run build`
+- Confirm rendered homepage output contains both new titles and authors.

--- a/.claude_tasks/2026-05-30_13-59-30/T2_publish_new_reviews.md
+++ b/.claude_tasks/2026-05-30_13-59-30/T2_publish_new_reviews.md
@@ -1,0 +1,15 @@
+# Task 2: Publish New Reviews
+
+## Description
+Publish the review update through a normal PR merge to `main` and confirm Vercel
+production is ready.
+
+## Decisions
+- Branch: `codex/add-new-app-store-reviews`.
+- Use GitHub PR and Vercel production deployment from `main`.
+- Do not deploy from a stale branch directly.
+
+## Verification
+- PR check passes.
+- Production deployment is ready.
+- Live homepage contains both new review titles.

--- a/plans/sprints/2026-05-30-add-new-app-store-reviews/prd.json
+++ b/plans/sprints/2026-05-30-add-new-app-store-reviews/prd.json
@@ -1,0 +1,47 @@
+{
+  "project": {
+    "name": "Add New App Store Reviews",
+    "repoRoot": "."
+  },
+  "definitionOfDone": {
+    "required": [
+      "All items pass",
+      "Project builds",
+      "Production homepage includes the new reviews"
+    ]
+  },
+  "files_changed": [
+    "src/components/LandingPage.tsx",
+    "plans/sprints/2026-05-30-add-new-app-store-reviews/prd.json",
+    "plans/sprints/2026-05-30-add-new-app-store-reviews/progress.txt",
+    "plans/sprints/2026-05-30-add-new-app-store-reviews/prompt.md"
+  ],
+  "items": [
+    {
+      "id": "REV-001",
+      "priority": 1,
+      "title": "Add two new App Store reviews",
+      "description": "Add the two user-supplied App Store reviews to the homepage review grid using the existing card layout and star visual.",
+      "acceptanceCriteria": [
+        "Homepage review grid includes the Cewj2000 review titled This app makes my hobby more organized.",
+        "Homepage review grid includes the BigJ71141 review titled Great app so far",
+        "Existing review section layout and App Store CTAs remain unchanged"
+      ],
+      "passes": false,
+      "tags": ["homepage", "reviews", "copy"]
+    },
+    {
+      "id": "REV-002",
+      "priority": 1,
+      "title": "Verify and publish reviews",
+      "description": "Build, verify rendered output, publish through PR, and confirm production includes the new reviews.",
+      "acceptanceCriteria": [
+        "npm run build completes successfully",
+        "Rendered homepage output contains both new review titles and authors",
+        "Production deployment is ready after merge"
+      ],
+      "passes": false,
+      "tags": ["verification", "production"]
+    }
+  ]
+}

--- a/plans/sprints/2026-05-30-add-new-app-store-reviews/prd.json
+++ b/plans/sprints/2026-05-30-add-new-app-store-reviews/prd.json
@@ -27,7 +27,7 @@
         "Homepage review grid includes the BigJ71141 review titled Great app so far",
         "Existing review section layout and App Store CTAs remain unchanged"
       ],
-      "passes": false,
+      "passes": true,
       "tags": ["homepage", "reviews", "copy"]
     },
     {

--- a/plans/sprints/2026-05-30-add-new-app-store-reviews/progress.txt
+++ b/plans/sprints/2026-05-30-add-new-app-store-reviews/progress.txt
@@ -2,7 +2,7 @@ Add New App Store Reviews
 =====================================================
 
 Started: 2026-05-30
-Status: In Progress (0/2 items)
+Status: In Progress (1/2 items)
 
 ## Goals
 - Add two newer App Store reviews to the homepage review grid.
@@ -12,8 +12,12 @@ Status: In Progress (0/2 items)
 ## Items
 
 ### Priority 1
-- [ ] REV-001: Add two new App Store reviews
+- [x] REV-001: Add two new App Store reviews
 - [ ] REV-002: Verify and publish reviews
+
+## Verification Notes
+- `npm run build` passed.
+- Local build output includes `This app makes my hobby more organized.`, `Great app so far`, `Cewj2000`, and `BigJ71141`.
 
 ## Files to Modify
 - src/components/LandingPage.tsx

--- a/plans/sprints/2026-05-30-add-new-app-store-reviews/progress.txt
+++ b/plans/sprints/2026-05-30-add-new-app-store-reviews/progress.txt
@@ -1,0 +1,36 @@
+Add New App Store Reviews
+=====================================================
+
+Started: 2026-05-30
+Status: In Progress (0/2 items)
+
+## Goals
+- Add two newer App Store reviews to the homepage review grid.
+- Keep the review UI and App Store CTAs unchanged.
+- Publish through the normal GitHub/Vercel production flow.
+
+## Items
+
+### Priority 1
+- [ ] REV-001: Add two new App Store reviews
+- [ ] REV-002: Verify and publish reviews
+
+## Files to Modify
+- src/components/LandingPage.tsx
+- plans/sprints/2026-05-30-add-new-app-store-reviews/prd.json
+- plans/sprints/2026-05-30-add-new-app-store-reviews/progress.txt
+- plans/sprints/2026-05-30-add-new-app-store-reviews/prompt.md
+
+## Deployment
+- Publish through GitHub PR merge to main.
+- Let Vercel deploy production from the merge commit.
+
+## Ralph Launch Commands
+
+```bash
+# Iterative (runs up to 25 iterations until all items pass):
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph.sh plans/sprints/2026-05-30-add-new-app-store-reviews 25
+
+# Single iteration:
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph_once.sh plans/sprints/2026-05-30-add-new-app-store-reviews
+```

--- a/plans/sprints/2026-05-30-add-new-app-store-reviews/prompt.md
+++ b/plans/sprints/2026-05-30-add-new-app-store-reviews/prompt.md
@@ -1,0 +1,29 @@
+# Add New App Store Reviews Sprint Prompt
+
+Add two user-supplied App Store reviews to the homepage review grid.
+
+## Review Copy
+
+### This app makes my hobby more organized.
+- Author: `Cewj2000`
+- Date: `May 19`
+- Text: `This app has made my bottle tracking so much easier. I hated going to a store and not being sure if I already had a bottle or not. Now with BarrelBook I can simply open the app and compare my collection to what is available on the shelves. I do also love that I can share my collection with my friends. It makes bottle shares so much more fun as we can look at what is potentially available to share.`
+
+### Great app so far
+- Author: `BigJ71141`
+- Date: `May 18`
+- Text: `Love it so far, I’d been looking for a way to keep track of my bottles other than making a spreadsheet and came across this. Only suggestion so far is that it would be awesome if the “spin to pick a pour” filters had an option for open bottles vs. unopened bottles. I try to keep my open bottles to a minimum but sometimes want to open one I haven’t tried yet.`
+
+## Constraints
+
+- Keep the existing review card layout.
+- Keep the five-star visual.
+- Do not redesign the reviews section.
+- Do not alter App Store rating hero copy, pricing, or CTAs.
+
+## Verification Commands
+
+```bash
+npm run build
+rg "This app makes my hobby more organized|Great app so far|Cewj2000|BigJ71141" .next src
+```

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -346,6 +346,20 @@ export default function LandingPage() {
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
             {[
               {
+                title: "This app makes my hobby more organized.",
+                text: "This app has made my bottle tracking so much easier. I hated going to a store and not being sure if I already had a bottle or not. Now with BarrelBook I can simply open the app and compare my collection to what is available on the shelves. I do also love that I can share my collection with my friends. It makes bottle shares so much more fun as we can look at what is potentially available to share.",
+                author: "Cewj2000",
+                date: "May 19, 2026",
+                version: "1.5",
+              },
+              {
+                title: "Great app so far",
+                text: "Love it so far, I’d been looking for a way to keep track of my bottles other than making a spreadsheet and came across this. Only suggestion so far is that it would be awesome if the “spin to pick a pour” filters had an option for open bottles vs. unopened bottles. I try to keep my open bottles to a minimum but sometimes want to open one I haven’t tried yet.",
+                author: "BigJ71141",
+                date: "May 18, 2026",
+                version: "1.5",
+              },
+              {
                 title: "Best Bourbon tracking App",
                 text: "BarrelBook has rapidly become one of my favorite apps. The ability to scan labels and instantly catalog bottles is a game changer. Tracking prices, locations, and personal notes makes managing a collection effortless. Highly recommend for any bourbon enthusiast!",
                 author: "MrWCBrown",


### PR DESCRIPTION
## Summary
- Add two newer App Store reviews to the homepage review grid.
- Keep the existing review card layout, five-star visual, and App Store CTAs unchanged.

## Reviews added
- `This app makes my hobby more organized.` by `Cewj2000`
- `Great app so far` by `BigJ71141`

## Verification
- `npm run build`
- Generated homepage output contains both new review titles and authors.
