### PR TITLE
Add bottle link web fallback

### DIFF
--- a/.claude_tasks/2026-05-30_14-09-26/SUMMARY.md
+++ b/.claude_tasks/2026-05-30_14-09-26/SUMMARY.md
@@ -1,0 +1,28 @@
+# Bottle Link Fallback Summary
+
+## Files Added
+- `src/app/bottles/[id]/page.tsx`
+- `.claude_tasks/2026-05-30_14-09-26/T1_private_bottle_handoff_route.md`
+- `.claude_tasks/2026-05-30_14-09-26/T2_bottle_universal_link_component.md`
+- `.claude_tasks/2026-05-30_14-09-26/T3_bottle_tests_and_verification.md`
+
+## Files Modified
+- `src/lib/apple-app-site-association.ts`
+- `scripts/test-promo-foundation.mjs`
+- `plans/sprints/2026-05-30-bottle-link-fallback/prd.json`
+- `plans/sprints/2026-05-30-bottle-link-fallback/progress.txt`
+
+## Overview
+- Added a private `/bottles/[id]` fallback page that opens `barrelbook://bottles/{encodedId}` and links to the App Store.
+- Added noindex/nofollow metadata and Smart App Banner metadata for the bottle handoff.
+- Added `/bottles/*` to the shared AASA payload while preserving existing universal-link components.
+- Extended the smoke script to cover route rendering, deep-link encoding, AASA components, and sitemap exclusion.
+
+## Verification
+- `npm run lint` passed with existing warnings in unrelated files.
+- `npm run build` passed.
+- `npm run test:promo` passed.
+
+## Next Steps
+- Review the branch diff and open a PR.
+- After the matching iOS route is available, test an owned bottle link on an iPhone with the updated app installed.

--- a/.claude_tasks/2026-05-30_14-09-26/T1_private_bottle_handoff_route.md
+++ b/.claude_tasks/2026-05-30_14-09-26/T1_private_bottle_handoff_route.md
@@ -1,0 +1,20 @@
+# T1 Private Bottle Handoff Route
+
+## Description
+Add a private website fallback route at `/bottles/[id]` that hands users off to the BarrelBook iOS app without exposing bottle data on the web.
+
+## Decisions
+- Keep the page generic and private: no bottle data fetches, no account lookups, and no displayed bottle metadata.
+- Trim the route parameter before use and URL-encode it for outbound deep links.
+- Return a 404 for an empty trimmed ID.
+- Reuse shared App Store constants from `src/lib/app-store.ts`.
+- Emit noindex/nofollow metadata and a Smart App Banner app argument pointing at the encoded bottle deep link.
+
+## Test Notes
+- Route rendering and deep-link href coverage will be added in the lightweight promo foundation test script.
+
+## Implementation Notes
+- Added `src/app/bottles/[id]/page.tsx`.
+- The page trims IDs, rejects empty values with `notFound()`, and encodes the ID for `barrelbook://bottles/{id}`.
+- The page uses generic app-handoff copy only and does not fetch or render bottle data.
+- Metadata uses `robots: { index: false, follow: false }` and Smart App Banner app arguments.

--- a/.claude_tasks/2026-05-30_14-09-26/T2_bottle_universal_link_component.md
+++ b/.claude_tasks/2026-05-30_14-09-26/T2_bottle_universal_link_component.md
@@ -1,0 +1,16 @@
+# T2 Bottle Universal Link Component
+
+## Description
+Update the Apple App Site Association helper so BarrelBook can claim website bottle links for app handoff.
+
+## Decisions
+- Add a dedicated `/bottles/*` component with a bottle-specific comment.
+- Preserve the existing `/scan`, `/collection`, `/store-picks`, `/p/*`, and `/gift/*` components.
+
+## Test Notes
+- AASA endpoint coverage will assert the new bottle component and the existing components remain present.
+
+## Implementation Notes
+- Added `BOTTLE_PATH_COMPONENT` for `/bottles/*`.
+- Kept the existing shared AASA route handlers unchanged.
+- Preserved `/scan`, `/collection`, `/store-picks`, `/p/*`, and `/gift/*` in the component list.

--- a/.claude_tasks/2026-05-30_14-09-26/T3_bottle_tests_and_verification.md
+++ b/.claude_tasks/2026-05-30_14-09-26/T3_bottle_tests_and_verification.md
@@ -1,0 +1,21 @@
+# T3 Bottle Tests And Verification
+
+## Description
+Extend lightweight website checks for the new bottle fallback route and AASA component, then run local verification.
+
+## Decisions
+- Extend `scripts/test-promo-foundation.mjs` instead of introducing a new test runner.
+- Verify a rendered sample route, expected deep link, App Store CTA, AASA `/bottles/*`, and sitemap exclusion.
+- Run lint, production build, and the promo foundation test before finalizing.
+
+## Test Notes
+- Commands planned: `npm run lint`, `npm run build`, and `npm run test:promo`.
+
+## Implementation Notes
+- Extended `scripts/test-promo-foundation.mjs` to verify `/bottles/testBottle123`, encoded bottle IDs, App Store CTA, Smart App Banner app argument, sitemap exclusion, and all expected AASA components.
+- Adjusted the bottle route normalization to decode once before trimming and re-encoding outbound deep links.
+
+## Verification
+- `npm run lint` passed with existing warnings in unrelated files.
+- `npm run build` passed.
+- `npm run test:promo` passed.

--- a/plans/ralph.sh
+++ b/plans/ralph.sh
@@ -5,7 +5,7 @@
 # is marked passes=true, or until max_iters is reached.
 #
 # Usage:
-#   RALPH_AGENT_CMD=./plans/adapters/claude_code.sh \
+#   RALPH_AGENT_CMD=./plans/adapters/Codex.sh \
 #     ./plans/ralph.sh plans/sprints/YYYY-MM-DD-slug [max_iters]
 #
 set -euo pipefail
@@ -19,7 +19,7 @@ if [[ -z "$SPRINT_DIR" || ! -d "$SPRINT_DIR" ]]; then
 fi
 
 if [[ -z "${RALPH_AGENT_CMD:-}" ]]; then
-  echo "RALPH_AGENT_CMD must be set (e.g. ./plans/adapters/claude_code.sh)" >&2
+  echo "RALPH_AGENT_CMD must be set (e.g. ./plans/adapters/Codex.sh)" >&2
   exit 1
 fi
 

--- a/plans/ralph_once.sh
+++ b/plans/ralph_once.sh
@@ -5,7 +5,7 @@
 # want to review the agent's work between iterations.
 #
 # Usage:
-#   RALPH_AGENT_CMD=./plans/adapters/claude_code.sh \
+#   RALPH_AGENT_CMD=./plans/adapters/Codex.sh \
 #     ./plans/ralph_once.sh plans/sprints/YYYY-MM-DD-slug
 #
 set -euo pipefail
@@ -18,7 +18,7 @@ if [[ -z "$SPRINT_DIR" || ! -d "$SPRINT_DIR" ]]; then
 fi
 
 if [[ -z "${RALPH_AGENT_CMD:-}" ]]; then
-  echo "RALPH_AGENT_CMD must be set (e.g. ./plans/adapters/claude_code.sh)" >&2
+  echo "RALPH_AGENT_CMD must be set (e.g. ./plans/adapters/Codex.sh)" >&2
   exit 1
 fi
 

--- a/plans/run_agent.sh
+++ b/plans/run_agent.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # Adapter dispatcher. Selects an adapter based on RALPH_ADAPTER (defaults to
-# claude_code) and forwards the sprint directory to it.
+# Codex) and forwards the sprint directory to it.
 #
 # Usage:
-#   RALPH_ADAPTER=claude_code ./plans/run_agent.sh <sprint_dir>
+#   RALPH_ADAPTER=Codex ./plans/run_agent.sh <sprint_dir>
 #
 set -euo pipefail
 
 SPRINT_DIR="${1:-}"
-ADAPTER="${RALPH_ADAPTER:-claude_code}"
+ADAPTER="${RALPH_ADAPTER:-Codex}"
 
 if [[ -z "$SPRINT_DIR" ]]; then
   echo "Usage: $0 <sprint_dir>" >&2

--- a/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
@@ -1,0 +1,67 @@
+{
+  "project": {
+    "name": "Bottle Link Fallback",
+    "repoRoot": "."
+  },
+  "definitionOfDone": {
+    "required": [
+      "All items pass",
+      "Project builds",
+      "No bottle data is fetched or displayed",
+      "No production push or deploy"
+    ]
+  },
+  "files_changed": [
+    "src/app/bottles/[id]/page.tsx",
+    "src/lib/apple-app-site-association.ts",
+    "scripts/test-promo-foundation.mjs",
+    "plans/sprints/2026-05-30-bottle-link-fallback/prd.json",
+    "plans/sprints/2026-05-30-bottle-link-fallback/progress.txt"
+  ],
+  "items": [
+    {
+      "id": "BLF-001",
+      "priority": 1,
+      "title": "Add private bottle handoff route",
+      "description": "Create the Next.js app-router route for /bottles/{id}. The page must trim and encode the route id for outbound app links, render app/install handoff copy only, and emit noindex/nofollow plus Smart App Banner metadata. It must not fetch or display bottle details.",
+      "acceptanceCriteria": [
+        "src/app/bottles/[id]/page.tsx exists and follows the existing async params pattern used by the app router routes",
+        "Open CTA href is barrelbook://bottles/{encodeURIComponent(trimmedId)}",
+        "Get BarrelBook CTA uses the shared APP_STORE_URL constant",
+        "generateMetadata emits robots index=false follow=false and apple-itunes-app with APP_STORE_APP_ID plus the encoded app argument",
+        "The rendered page states the bottle opens only for the signed-in account that owns it",
+        "No bottle details, notes, images, prices, values, user IDs, account IDs, or network fetches are added"
+      ],
+      "passes": false,
+      "tags": ["route", "privacy"]
+    },
+    {
+      "id": "BLF-002",
+      "priority": 1,
+      "title": "Add bottle universal-link component",
+      "description": "Update the Apple App Site Association helper so iOS can claim /bottles/* while preserving all existing handoff components.",
+      "acceptanceCriteria": [
+        "src/lib/apple-app-site-association.ts includes a /bottles/* component with a bottle-specific comment",
+        "Existing /scan, /collection, /store-picks, /p/*, and /gift/* components remain present",
+        "Both existing AASA route handlers continue to serve the same shared payload"
+      ],
+      "passes": false,
+      "tags": ["aasa", "universal-links"]
+    },
+    {
+      "id": "BLF-003",
+      "priority": 2,
+      "title": "Cover bottle fallback with lightweight tests",
+      "description": "Extend the existing lightweight website checks to cover the bottle fallback route, encoded deep-link href, AASA /bottles/* component, and sitemap exclusion.",
+      "acceptanceCriteria": [
+        "scripts/test-promo-foundation.mjs checks /bottles/testBottle123 renders",
+        "The test verifies href=\"barrelbook://bottles/testBottle123\" for a sample id",
+        "The test verifies /bottles/* appears in the AASA components",
+        "The test verifies sitemap.xml does not include /bottles/",
+        "npm run lint, npm run build, and npm run test:promo pass"
+      ],
+      "passes": false,
+      "tags": ["tests"]
+    }
+  ]
+}

--- a/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
@@ -32,7 +32,7 @@
         "The rendered page states the bottle opens only for the signed-in account that owns it",
         "No bottle details, notes, images, prices, values, user IDs, account IDs, or network fetches are added"
       ],
-      "passes": false,
+      "passes": true,
       "tags": ["route", "privacy"]
     },
     {

--- a/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
@@ -60,7 +60,7 @@
         "The test verifies sitemap.xml does not include /bottles/",
         "npm run lint, npm run build, and npm run test:promo pass"
       ],
-      "passes": false,
+      "passes": true,
       "tags": ["tests"]
     }
   ]

--- a/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/prd.json
@@ -45,7 +45,7 @@
         "Existing /scan, /collection, /store-picks, /p/*, and /gift/* components remain present",
         "Both existing AASA route handlers continue to serve the same shared payload"
       ],
-      "passes": false,
+      "passes": true,
       "tags": ["aasa", "universal-links"]
     },
     {

--- a/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
@@ -2,7 +2,7 @@ Bottle Link Fallback
 =====================================================
 
 Started: 2026-05-30
-Status: In Progress (0/3 items)
+Status: In Progress (1/3 items)
 
 ## Goals
 - Add a privacy-safe web fallback at /bottles/{id}.
@@ -12,7 +12,7 @@ Status: In Progress (0/3 items)
 ## Items
 
 ### Priority 1
-- [ ] BLF-001: Add private bottle handoff route
+- [x] BLF-001: Add private bottle handoff route
 - [ ] BLF-002: Add bottle universal-link component
 
 ### Priority 2

--- a/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
@@ -1,0 +1,29 @@
+Bottle Link Fallback
+=====================================================
+
+Started: 2026-05-30
+Status: In Progress (0/3 items)
+
+## Goals
+- Add a privacy-safe web fallback at /bottles/{id}.
+- Enable iOS universal-link handoff for /bottles/*.
+- Cover the route and AASA behavior with existing lightweight checks.
+
+## Items
+
+### Priority 1
+- [ ] BLF-001: Add private bottle handoff route
+- [ ] BLF-002: Add bottle universal-link component
+
+### Priority 2
+- [ ] BLF-003: Cover bottle fallback with lightweight tests
+
+## Files to Modify
+- src/app/bottles/[id]/page.tsx
+- src/lib/apple-app-site-association.ts
+- scripts/test-promo-foundation.mjs
+- plans/sprints/2026-05-30-bottle-link-fallback/prd.json
+- plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
+
+## Deployment
+- No push, deploy, or Vercel alias changes in this sprint unless explicitly requested later.

--- a/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
@@ -2,7 +2,7 @@ Bottle Link Fallback
 =====================================================
 
 Started: 2026-05-30
-Status: In Progress (2/3 items)
+Status: Complete (3/3 items)
 
 ## Goals
 - Add a privacy-safe web fallback at /bottles/{id}.
@@ -16,7 +16,12 @@ Status: In Progress (2/3 items)
 - [x] BLF-002: Add bottle universal-link component
 
 ### Priority 2
-- [ ] BLF-003: Cover bottle fallback with lightweight tests
+- [x] BLF-003: Cover bottle fallback with lightweight tests
+
+## Verification
+- `npm run lint` passed with existing warnings in unrelated files.
+- `npm run build` passed.
+- `npm run test:promo` passed.
 
 ## Files to Modify
 - src/app/bottles/[id]/page.tsx

--- a/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/progress.txt
@@ -2,7 +2,7 @@ Bottle Link Fallback
 =====================================================
 
 Started: 2026-05-30
-Status: In Progress (1/3 items)
+Status: In Progress (2/3 items)
 
 ## Goals
 - Add a privacy-safe web fallback at /bottles/{id}.
@@ -13,7 +13,7 @@ Status: In Progress (1/3 items)
 
 ### Priority 1
 - [x] BLF-001: Add private bottle handoff route
-- [ ] BLF-002: Add bottle universal-link component
+- [x] BLF-002: Add bottle universal-link component
 
 ### Priority 2
 - [ ] BLF-003: Cover bottle fallback with lightweight tests

--- a/plans/sprints/2026-05-30-bottle-link-fallback/prompt.md
+++ b/plans/sprints/2026-05-30-bottle-link-fallback/prompt.md
@@ -1,0 +1,50 @@
+# Bottle Link Fallback Sprint Prompt
+
+Implement exactly one PRD item per Ralph iteration. Keep the branch scoped to
+the bottle-link fallback and do not bring in preserved paid-conversion or
+creator-promo WIP from other branches.
+
+## Verification Command
+
+Run this before marking an item as passing:
+
+```bash
+npm run lint && npm run build && npm run test:promo
+```
+
+If an item only changes sprint bookkeeping and the command was already run
+cleanly for the relevant code state, note that in `progress.txt`; otherwise run
+the full command.
+
+## Product Constraints
+
+- The website route is a handoff/fallback page, not a public bottle page.
+- Do not fetch from Firebase, Firestore, OpenAI, app APIs, or any account
+  service.
+- Do not render bottle details, bottle names, notes, image URLs, pricing,
+  valuation, user IDs, account IDs, owner data, or private metadata.
+- The page should explain that the bottle opens only if it belongs to the
+  signed-in BarrelBook account.
+- Render both actions everywhere: primary `Open in BarrelBook`, secondary
+  `Get BarrelBook`. Do not add user-agent detection.
+- Use shared `APP_STORE_APP_ID` and `APP_STORE_URL` from `src/lib/app-store.ts`.
+- Build bottle app links as `barrelbook://bottles/{encodeURIComponent(trimmedId)}`.
+- Invalid-looking but non-empty IDs should not crash.
+- If a route id trims to an empty string, use `notFound()`.
+- Keep `/bottles/` out of `sitemap.ts`.
+
+## Technical Context
+
+- This is a Next.js 16 app-router site. Existing dynamic routes use async
+  `params` props.
+- Existing AASA payload is centralized in
+  `src/lib/apple-app-site-association.ts` and served from both
+  `/apple-app-site-association` and `/.well-known/apple-app-site-association`.
+- Existing lightweight route checks live in `scripts/test-promo-foundation.mjs`.
+
+## Safety
+
+- Do not push, deploy, or run Vercel deployment commands.
+- Do not use `git reset --hard`, `git clean`, or destructive checkout commands.
+- Commit each completed PRD item with the required `<ITEM-ID>: <short title>`
+  message format.

--- a/scripts/test-promo-foundation.mjs
+++ b/scripts/test-promo-foundation.mjs
@@ -6,6 +6,7 @@ import { setTimeout as delay } from "node:timers/promises";
 const PORT = process.env.PROMO_TEST_PORT ?? "3107";
 const HOST = "http://127.0.0.1:" + PORT;
 const AASA_APP_ID = "TESTTEAM.com.barrelbook.app";
+const APP_STORE_URL = "https://apps.apple.com/us/app/barrelbook-whiskey-catalog/id6751737898";
 const TESTFLIGHT_URL = "https://testflight.apple.com/join/TESTFNF";
 const FNF_SANDBOX_CODE = "FNF-SANDBOX-CODE";
 const BLACKSHIRT_PLUS_CODE = "BLACKSHIRTPLUS20";
@@ -361,6 +362,59 @@ async function assertNotFound(pathname) {
   assert.match(html, /not found/i, "Expected " + pathname + " to render a 404 page");
 }
 
+async function assertBottleFallbackPage() {
+  const sampleResponse = await fetch(HOST + "/bottles/testBottle123");
+  const sampleHtml = await sampleResponse.text();
+
+  assert.equal(sampleResponse.status, 200, "Expected /bottles/testBottle123 to render");
+
+  for (const snippet of [
+    "Open this bottle in BarrelBook",
+    "This web page is an app handoff, not a public bottle page.",
+    "signed-in BarrelBook account owns it",
+    "Bottle details stay private and are not shown on the web.",
+  ]) {
+    assert.ok(
+      sampleHtml.includes(snippet),
+      "Expected /bottles/testBottle123 to include \"" + snippet + "\""
+    );
+  }
+
+  assert.ok(
+    sampleHtml.includes('href="barrelbook://bottles/testBottle123"'),
+    "Expected /bottles/testBottle123 to expose the encoded bottle deep link"
+  );
+  assert.ok(
+    sampleHtml.includes('href="' + APP_STORE_URL + '"'),
+    "Expected /bottles/testBottle123 to expose the App Store CTA"
+  );
+  assert.ok(
+    sampleHtml.includes('name="apple-itunes-app"')
+      && sampleHtml.includes("app-argument=barrelbook://bottles/testBottle123"),
+    "Expected /bottles/testBottle123 to expose a Smart App Banner for the bottle link"
+  );
+
+  for (const snippet of ["MSRP", "Secondary", "imageUrl", "userId", "accountId"]) {
+    assert.ok(
+      !sampleHtml.includes(snippet),
+      "Expected /bottles/testBottle123 to avoid private bottle snippet \"" + snippet + "\""
+    );
+  }
+
+  const encodedResponse = await fetch(HOST + "/bottles/test%20Bottle%20123");
+  const encodedHtml = await encodedResponse.text();
+
+  assert.equal(
+    encodedResponse.status,
+    200,
+    "Expected /bottles/test%20Bottle%20123 to render"
+  );
+  assert.ok(
+    encodedHtml.includes('href="barrelbook://bottles/test%20Bottle%20123"'),
+    "Expected bottle IDs with spaces to stay URL-encoded in the deep link"
+  );
+}
+
 async function assertRobotsDisallowsPromoPaths() {
   const response = await fetch(HOST + "/robots.txt");
   const text = await response.text();
@@ -387,6 +441,14 @@ async function assertSitemapExcludesPromoPages() {
   assert.ok(!text.includes("/p/"), "Expected sitemap.xml to exclude promo pages");
   assert.ok(!text.includes("blackshirt"), "Expected sitemap.xml to exclude Black Shirt alias");
   assert.ok(!text.includes("thebourbontrail"), "Expected sitemap.xml to exclude The Bourbon Trail alias");
+  assert.ok(!text.includes("/bottles/"), "Expected sitemap.xml to exclude bottle pages");
+}
+
+function assertAasaComponent(components, path, comment) {
+  assert.ok(
+    components.some((component) => component?.["/"] === path && component?.comment === comment),
+    "Expected " + path + " AASA component to be present"
+  );
 }
 
 async function assertAasaEndpoints() {
@@ -420,13 +482,35 @@ async function assertAasaEndpoints() {
     Array.isArray(details[0].components),
     "Expected applinks components to be an array"
   );
-  assert.ok(
-    details[0].components.some(
-      (component) =>
-        component?.["/"] === "/p/*" &&
-        component?.comment === "Canonical BarrelBook promo links"
-    ),
-    "Expected promo AASA component to be present"
+  assertAasaComponent(
+    details[0].components,
+    "/scan",
+    "Universal link handoff to the BarrelBook scan experience"
+  );
+  assertAasaComponent(
+    details[0].components,
+    "/collection",
+    "Universal link handoff to the BarrelBook collection experience"
+  );
+  assertAasaComponent(
+    details[0].components,
+    "/store-picks",
+    "Universal link handoff to the BarrelBook store-picks experience"
+  );
+  assertAasaComponent(
+    details[0].components,
+    "/bottles/*",
+    "Universal link handoff to private BarrelBook bottle links"
+  );
+  assertAasaComponent(
+    details[0].components,
+    "/p/*",
+    "Canonical BarrelBook promo links"
+  );
+  assertAasaComponent(
+    details[0].components,
+    "/gift/*",
+    "Canonical BarrelBook Golden Ticket links"
   );
 }
 
@@ -444,6 +528,7 @@ async function main() {
     await assertRuntimeRedirect("/blackshirt", "/p/blackshirt");
     await assertRuntimeRedirect("/thebourbontrail", "/p/thebourbontrail");
     await assertPromoPage("/qa/fnf");
+    await assertBottleFallbackPage();
     await assertNotFound("/p/unknown-slug");
     await assertRobotsDisallowsPromoPaths();
     await assertSitemapExcludesPromoPages();

--- a/src/app/bottles/[id]/page.tsx
+++ b/src/app/bottles/[id]/page.tsx
@@ -10,8 +10,16 @@ interface BottlePageProps {
   }>;
 }
 
+function decodeBottleId(id: string): string {
+  try {
+    return decodeURIComponent(id);
+  } catch {
+    return id;
+  }
+}
+
 function normalizeBottleId(id: string): string {
-  return id.trim();
+  return decodeBottleId(id).trim();
 }
 
 // T1: only the normalized, encoded route ID is used for app handoff URLs.

--- a/src/app/bottles/[id]/page.tsx
+++ b/src/app/bottles/[id]/page.tsx
@@ -1,0 +1,180 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { APP_STORE_APP_ID, APP_STORE_URL } from "@/lib/app-store";
+
+interface BottlePageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+function normalizeBottleId(id: string): string {
+  return id.trim();
+}
+
+// T1: only the normalized, encoded route ID is used for app handoff URLs.
+function getEncodedBottleId(id: string): string {
+  return encodeURIComponent(normalizeBottleId(id));
+}
+
+function getBottleAppOpenUrl(id: string): string {
+  return `barrelbook://bottles/${getEncodedBottleId(id)}`;
+}
+
+export async function generateMetadata({
+  params,
+}: BottlePageProps): Promise<Metadata> {
+  const { id } = await params;
+  const normalizedId = normalizeBottleId(id);
+
+  if (normalizedId.length === 0) {
+    notFound();
+  }
+
+  const encodedId = getEncodedBottleId(normalizedId);
+  const appOpenUrl = getBottleAppOpenUrl(normalizedId);
+  const canonicalPath = `/bottles/${encodedId}`;
+  const description =
+    "Open this private bottle link in BarrelBook on iPhone, or install BarrelBook from the App Store.";
+
+  return {
+    title: "Open Bottle in BarrelBook",
+    description,
+    alternates: {
+      canonical: canonicalPath,
+    },
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_APP_ID}, app-argument=${appOpenUrl}`,
+    },
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      type: "website",
+      url: canonicalPath,
+      title: "Open Bottle in BarrelBook",
+      description,
+    },
+    twitter: {
+      card: "summary",
+      title: "Open Bottle in BarrelBook",
+      description,
+    },
+  };
+}
+
+export default async function BottlePage({ params }: BottlePageProps) {
+  const { id } = await params;
+  const normalizedId = normalizeBottleId(id);
+
+  if (normalizedId.length === 0) {
+    notFound();
+  }
+
+  const appOpenUrl = getBottleAppOpenUrl(normalizedId);
+
+  return (
+    <main className="min-h-screen bg-[#0A0A0A] text-white">
+      <header className="border-b border-[#333333] bg-[#0A0A0A]/95 backdrop-blur-md">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
+          <Link href="/" className="flex items-center gap-3">
+            <Image
+              src="/BarrelBook%20Logo%20Large.png"
+              alt="BarrelBook"
+              width={220}
+              height={48}
+              className="h-8 w-auto"
+              priority
+            />
+          </Link>
+          <a
+            href={APP_STORE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center rounded-full border border-[#D2691E]/40 bg-[#D2691E]/10 px-4 py-2 text-sm font-medium text-white transition hover:border-[#D2691E] hover:bg-[#D2691E]/20"
+          >
+            Get BarrelBook
+          </a>
+        </div>
+      </header>
+
+      <section className="px-4 py-12 sm:px-6 lg:px-8 lg:py-20">
+        <div className="mx-auto max-w-5xl">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)] lg:items-start">
+            <div className="max-w-3xl">
+              <div className="text-sm font-semibold uppercase tracking-[0.2em] text-[#F2C19A]">
+                Private BarrelBook Link
+              </div>
+              <h1 className="mt-4 text-4xl font-semibold tracking-tight sm:text-5xl">
+                Open this bottle in BarrelBook
+              </h1>
+              <p className="mt-4 max-w-2xl text-lg text-[#D0D0D0] sm:text-xl">
+                This web page is an app handoff, not a public bottle page.
+              </p>
+              <p className="mt-6 max-w-3xl text-base leading-8 text-[#BDBDBD]">
+                The link opens the bottle in the iOS app if BarrelBook is installed and the signed-in BarrelBook account owns it. Bottle details stay private and are not shown on the web.
+              </p>
+            </div>
+
+            <aside className="space-y-6">
+              <div className="rounded-[28px] border border-[#3B3B3B] bg-[radial-gradient(circle_at_top,#3A1D0D,transparent_55%),linear-gradient(180deg,#171717_0%,#101010_100%)] p-6 shadow-[0_28px_80px_rgba(0,0,0,0.35)] sm:p-8">
+                <h2 className="text-2xl font-semibold text-white">Open in the app</h2>
+                <p className="mt-4 text-base leading-7 text-[#CFCFCF]">
+                  If BarrelBook is already installed on your iPhone, this should take you straight to the bottle.
+                </p>
+                <div className="mt-6 flex flex-col gap-3">
+                  <a
+                    href={appOpenUrl}
+                    className="inline-flex w-full items-center justify-center rounded-full bg-[#D2691E] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#B85714]"
+                  >
+                    Open in BarrelBook
+                  </a>
+                  <a
+                    href={APP_STORE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex w-full items-center justify-center rounded-full border border-[#D2691E]/45 bg-transparent px-5 py-3 text-base font-semibold text-white transition hover:border-[#D2691E] hover:bg-[#D2691E]/10"
+                  >
+                    Get BarrelBook
+                  </a>
+                </div>
+                <div className="mt-6 rounded-2xl border border-[#D2691E]/35 bg-[#0F0F0F] p-5">
+                  <div className="text-sm uppercase tracking-[0.2em] text-[#F2C19A]">
+                    Account required
+                  </div>
+                  <p className="mt-3 text-base leading-7 text-[#D4D4D4]">
+                    Sign in to the BarrelBook account that owns this bottle. If you install the app first, return to this page and tap Open in BarrelBook again.
+                  </p>
+                </div>
+              </div>
+
+              <div className="rounded-[24px] border border-[#262626] bg-[#111111] p-5 sm:p-6">
+                <h2 className="text-2xl font-semibold">If the app does not open</h2>
+                <ol className="mt-6 space-y-4">
+                  {[
+                    "Install BarrelBook from the App Store if needed.",
+                    "Create or sign in to your BarrelBook account.",
+                    "Return to this page and tap Open in BarrelBook.",
+                    "If the link still does not open, open BarrelBook manually and check that you are signed in.",
+                  ].map((step, index) => (
+                    <li key={step} className="flex gap-4">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[#D2691E]/15 text-sm font-semibold text-[#F2C19A]">
+                        {index + 1}
+                      </div>
+                      <div className="pt-1 text-base leading-7 text-[#D4D4D4]">
+                        {step}
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/lib/apple-app-site-association.ts
+++ b/src/lib/apple-app-site-association.ts
@@ -23,6 +23,11 @@ const STORE_PICKS_PATH_COMPONENT = {
   comment: "Universal link handoff to the BarrelBook store-picks experience",
 } as const;
 
+const BOTTLE_PATH_COMPONENT = {
+  "/": "/bottles/*",
+  comment: "Universal link handoff to private BarrelBook bottle links",
+} as const;
+
 export const AASA_RESPONSE_HEADERS = {
   "Cache-Control": "public, max-age=300, s-maxage=300",
   "Content-Type": "application/json; charset=utf-8",
@@ -48,6 +53,7 @@ export function getAppleAppSiteAssociation() {
             SCAN_PATH_COMPONENT,
             COLLECTION_PATH_COMPONENT,
             STORE_PICKS_PATH_COMPONENT,
+            BOTTLE_PATH_COMPONENT,
             PROMO_PATH_COMPONENT,
             GOLDEN_TICKET_PATH_COMPONENT,
           ],


### PR DESCRIPTION
## Summary
- add a private /bottles/[id] web fallback that hands off to the BarrelBook iOS app
- add /bottles/* to the shared Apple App Site Association payload
- extend lightweight website checks for the bottle route, AASA component, and sitemap exclusion

## Validation
- npm run lint (passes with existing unrelated warnings)
- npm run build
- npm run test:promo

## Deployment Notes
- No bottle data is fetched or displayed on the web page
- Production rollout should happen by merging this PR to main and allowing Vercel to deploy main