### PR TITLE
Update App Store review count messaging to 125+

### DIFF
--- a/.claude_tasks/2026-06-01_10-09-03/SUMMARY.md
+++ b/.claude_tasks/2026-06-01_10-09-03/SUMMARY.md
@@ -1,0 +1,31 @@
+# Review Count 125 Refresh Summary
+
+## Files Added / Modified
+
+- Added `.claude_tasks/2026-06-01_10-09-03/` task records and this summary.
+- Added `plans/sprints/2026-06-01-review-count-125/` Ralph sprint records.
+- Modified `src/lib/app-store.ts`.
+
+## Overview
+
+- Updated exact structured-data App Store review count from `116` to `126`.
+- Updated rounded public App Store rating count from `100+` to `125+`.
+- Preserved the App Store URL, rating value, rating-link component, homepage layout, and JSON-LD wiring.
+
+## Verification
+
+- `npm ci` was required in the fresh worktree before building.
+- `npm run build` passed.
+- Focused rendered-output checks confirmed:
+  - source exact count is `126`
+  - source display count is `125+`
+  - rendered public copy uses `125+`
+  - rendered aria label uses `125+`
+  - rendered JSON-LD `reviewCount` is `126`
+  - stale rendered `100+ App Store ratings` copy is absent
+
+## Next Recommended Steps
+
+- Push `codex/update-review-count-125` and open a small PR.
+- Merge to `main` and allow Vercel to deploy production.
+- Optionally address the existing npm audit findings separately from this copy update.

--- a/.claude_tasks/2026-06-01_10-09-03/T1_isolate_worktree_and_scaffold_sprint.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T1_isolate_worktree_and_scaffold_sprint.md
@@ -1,0 +1,18 @@
+# Task 1: Isolate Worktree and Scaffold Sprint
+
+## Description
+
+Preserve the existing dirty `barrelbook-website` checkout by creating a clean sibling worktree from `origin/main`, then scaffold the required task log and Ralph sprint before changing website copy.
+
+## Decisions
+
+- Use a sibling worktree at `/Users/petereilly2021/Projects/barrelbook-website-review-count-125`.
+- Use branch `codex/update-review-count-125` based on `origin/main`.
+- Keep setup changes separate from product copy changes so the existing paid-conversion/ads branch remains untouched.
+
+## Code Snippets
+
+```bash
+git worktree add -b codex/update-review-count-125 /Users/petereilly2021/Projects/barrelbook-website-review-count-125 origin/main
+```
+

--- a/.claude_tasks/2026-06-01_10-09-03/T2_locate_review_messaging.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T2_locate_review_messaging.md
@@ -10,9 +10,15 @@ Find all website references to the App Store rating/review count so the update i
 - Treat `src/lib/app-store.ts` as the likely source of truth because the display count is centralized there.
 - Avoid redesigning the rating link or homepage.
 
+## Findings
+
+- `src/lib/app-store.ts` contains `APP_STORE_RATING_COUNT = "116"` and `APP_STORE_RATING_DISPLAY_COUNT = "100+"`.
+- `src/components/AppStoreRatingLink.tsx` renders the public rating link and accessibility label from those constants.
+- `src/app/page.tsx` uses `APP_STORE_RATING_COUNT` and `APP_STORE_RATING_VALUE` for SoftwareApplication JSON-LD.
+- No product-copy edit is needed outside the centralized constants unless verification reveals generated stale output.
+
 ## Code Snippets
 
 ```bash
 rg -n "100\\+|App Store ratings|reviews|reviewCount|ratingValue" src
 ```
-

--- a/.claude_tasks/2026-06-01_10-09-03/T2_locate_review_messaging.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T2_locate_review_messaging.md
@@ -1,0 +1,18 @@
+# Task 2: Locate Review Messaging
+
+## Description
+
+Find all website references to the App Store rating/review count so the update is complete and scoped.
+
+## Decisions
+
+- Start with repository search for `100+`, `App Store ratings`, `reviewCount`, and `ratingValue`.
+- Treat `src/lib/app-store.ts` as the likely source of truth because the display count is centralized there.
+- Avoid redesigning the rating link or homepage.
+
+## Code Snippets
+
+```bash
+rg -n "100\\+|App Store ratings|reviews|reviewCount|ratingValue" src
+```
+

--- a/.claude_tasks/2026-06-01_10-09-03/T3_update_review_count_copy.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T3_update_review_count_copy.md
@@ -12,5 +12,14 @@ Update the public website messaging from `100+` App Store ratings/reviews to `12
 
 ## Code Snippets
 
-To be added after implementation.
+```ts
+// REV-001: keep structured data exact while public copy uses a durable rounded count.
+export const APP_STORE_RATING_COUNT = "126";
+export const APP_STORE_RATING_DISPLAY_COUNT = "125+";
+```
 
+## Outcome
+
+- Updated the exact structured-data review count to `126`.
+- Updated the rounded public count to `125+`.
+- Left the App Store URL, rating value, component layout, and rating-link markup unchanged.

--- a/.claude_tasks/2026-06-01_10-09-03/T3_update_review_count_copy.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T3_update_review_count_copy.md
@@ -1,0 +1,16 @@
+# Task 3: Update Review Count Copy
+
+## Description
+
+Update the public website messaging from `100+` App Store ratings/reviews to `125+`, using the user-provided current count of 126 as the source of truth.
+
+## Decisions
+
+- Keep public copy rounded and durable as `125+`.
+- If exact structured-data constants are present, update the exact count to `126`.
+- Preserve the existing App Store URL, rating value, component layout, and visual treatment.
+
+## Code Snippets
+
+To be added after implementation.
+

--- a/.claude_tasks/2026-06-01_10-09-03/T4_verify_build_and_copy.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T4_verify_build_and_copy.md
@@ -1,0 +1,18 @@
+# Task 4: Verify Build and Copy
+
+## Description
+
+Run the relevant Next.js verification and confirm the rendered/source output contains the new `125+` messaging and no stale `100+` App Store count.
+
+## Decisions
+
+- Use `npm run build` as the primary verification command.
+- Use `rg` against `src` and build output for targeted copy checks.
+
+## Code Snippets
+
+```bash
+npm run build
+rg "125\\+|reviewCount.*126|APP_STORE_RATING_DISPLAY_COUNT" src .next
+```
+

--- a/.claude_tasks/2026-06-01_10-09-03/T4_verify_build_and_copy.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T4_verify_build_and_copy.md
@@ -16,3 +16,15 @@ npm run build
 rg "125\\+|reviewCount.*126|APP_STORE_RATING_DISPLAY_COUNT" src .next
 ```
 
+## Verification Results
+
+- Initial `npm run build` failed because the clean worktree did not have `node_modules`; ran `npm ci` from `package-lock.json`.
+- `npm ci` completed and reported existing audit findings: 4 moderate and 5 high vulnerabilities.
+- `npm run build` passed with Next.js 16.1.0.
+- Focused rendered-output checks passed:
+  - source exact count is `126`
+  - source display count is `125+`
+  - rendered public copy uses `125+`
+  - rendered aria label uses `125+`
+  - rendered JSON-LD `reviewCount` is `126`
+  - stale rendered `100+ App Store ratings` copy is absent

--- a/.claude_tasks/2026-06-01_10-09-03/T5_commit_and_summarize.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T5_commit_and_summarize.md
@@ -1,0 +1,18 @@
+# Task 5: Commit and Summarize
+
+## Description
+
+Review the scoped diff, commit the final website change, and create the required task-folder summary.
+
+## Decisions
+
+- Keep commits scoped: setup first, product copy second.
+- Do not include unrelated files or changes from the original checkout.
+
+## Code Snippets
+
+```bash
+git status --short
+git diff --stat
+```
+

--- a/.claude_tasks/2026-06-01_10-09-03/T5_commit_and_summarize.md
+++ b/.claude_tasks/2026-06-01_10-09-03/T5_commit_and_summarize.md
@@ -16,3 +16,14 @@ git status --short
 git diff --stat
 ```
 
+## Final Diff Review
+
+- Source change is limited to `src/lib/app-store.ts`.
+- `AppStoreRatingLink` and homepage JSON-LD consume the updated constants without direct edits.
+- Ralph/task bookkeeping files document the plan, implementation, and verification.
+
+## Outcome
+
+- Created `SUMMARY.md`.
+- Marked `REV-002` passing and sprint status complete.
+- Prepared the final commit for the review-count refresh.

--- a/plans/sprints/2026-06-01-review-count-125/prd.json
+++ b/plans/sprints/2026-06-01-review-count-125/prd.json
@@ -1,0 +1,56 @@
+{
+  "project": {
+    "name": "Review Count 125 Refresh",
+    "repoRoot": "."
+  },
+  "definitionOfDone": {
+    "required": [
+      "All items pass",
+      "Project builds",
+      "No stale 100+ App Store rating/review count remains"
+    ]
+  },
+  "files_changed": [
+    "src/lib/app-store.ts",
+    "src/components/AppStoreRatingLink.tsx",
+    ".claude_tasks/2026-06-01_10-09-03/T1_isolate_worktree_and_scaffold_sprint.md",
+    ".claude_tasks/2026-06-01_10-09-03/T2_locate_review_messaging.md",
+    ".claude_tasks/2026-06-01_10-09-03/T3_update_review_count_copy.md",
+    ".claude_tasks/2026-06-01_10-09-03/T4_verify_build_and_copy.md",
+    ".claude_tasks/2026-06-01_10-09-03/T5_commit_and_summarize.md",
+    "plans/sprints/2026-06-01-review-count-125/prd.json",
+    "plans/sprints/2026-06-01-review-count-125/progress.txt",
+    "plans/sprints/2026-06-01-review-count-125/prompt.md"
+  ],
+  "items": [
+    {
+      "id": "REV-001",
+      "priority": 1,
+      "title": "Update App Store review count messaging",
+      "description": "Update centralized App Store rating/review count data so public messaging uses 125+ while exact machine-readable review count reflects the user-provided current count of 126.",
+      "acceptanceCriteria": [
+        "Public rating link copy displays 125+ App Store ratings",
+        "Accessible rating label uses 125+ for the rounded public count",
+        "Exact structured-data review count is 126 if an exact review-count constant is present",
+        "App Store URL, rating value, and layout are unchanged"
+      ],
+      "passes": false,
+      "tags": ["copy", "homepage", "seo"]
+    },
+    {
+      "id": "REV-002",
+      "priority": 1,
+      "title": "Verify build and stale copy removal",
+      "description": "Run the website verification command and confirm the repository/build output contains the refreshed count without stale 100+ App Store count messaging.",
+      "acceptanceCriteria": [
+        "npm run build completes successfully",
+        "Repository search confirms 125+ App Store rating messaging is present",
+        "Repository search confirms stale 100+ App Store rating messaging is absent",
+        "Task summary records files changed and verification results"
+      ],
+      "passes": false,
+      "tags": ["verification", "summary"]
+    }
+  ]
+}
+

--- a/plans/sprints/2026-06-01-review-count-125/prd.json
+++ b/plans/sprints/2026-06-01-review-count-125/prd.json
@@ -34,7 +34,7 @@
         "Exact structured-data review count is 126 if an exact review-count constant is present",
         "App Store URL, rating value, and layout are unchanged"
       ],
-      "passes": false,
+      "passes": true,
       "tags": ["copy", "homepage", "seo"]
     },
     {
@@ -53,4 +53,3 @@
     }
   ]
 }
-

--- a/plans/sprints/2026-06-01-review-count-125/prd.json
+++ b/plans/sprints/2026-06-01-review-count-125/prd.json
@@ -12,12 +12,12 @@
   },
   "files_changed": [
     "src/lib/app-store.ts",
-    "src/components/AppStoreRatingLink.tsx",
     ".claude_tasks/2026-06-01_10-09-03/T1_isolate_worktree_and_scaffold_sprint.md",
     ".claude_tasks/2026-06-01_10-09-03/T2_locate_review_messaging.md",
     ".claude_tasks/2026-06-01_10-09-03/T3_update_review_count_copy.md",
     ".claude_tasks/2026-06-01_10-09-03/T4_verify_build_and_copy.md",
     ".claude_tasks/2026-06-01_10-09-03/T5_commit_and_summarize.md",
+    ".claude_tasks/2026-06-01_10-09-03/SUMMARY.md",
     "plans/sprints/2026-06-01-review-count-125/prd.json",
     "plans/sprints/2026-06-01-review-count-125/progress.txt",
     "plans/sprints/2026-06-01-review-count-125/prompt.md"
@@ -48,7 +48,7 @@
         "Repository search confirms stale 100+ App Store rating messaging is absent",
         "Task summary records files changed and verification results"
       ],
-      "passes": false,
+      "passes": true,
       "tags": ["verification", "summary"]
     }
   ]

--- a/plans/sprints/2026-06-01-review-count-125/progress.txt
+++ b/plans/sprints/2026-06-01-review-count-125/progress.txt
@@ -15,6 +15,12 @@ Status: In Progress (1/2 items)
 - [x] REV-001: Update App Store review count messaging
 - [ ] REV-002: Verify build and stale copy removal
 
+## Verification Notes
+- `npm ci` was required in the fresh worktree before building.
+- `npm run build` passed.
+- Rendered homepage output contains `125+` public rating copy and JSON-LD `reviewCount` of `126`.
+- Rendered homepage output no longer contains stale `100+ App Store ratings` copy.
+
 ## Files to Modify
 - src/lib/app-store.ts
 - src/components/AppStoreRatingLink.tsx

--- a/plans/sprints/2026-06-01-review-count-125/progress.txt
+++ b/plans/sprints/2026-06-01-review-count-125/progress.txt
@@ -2,7 +2,7 @@ Review Count 125 Refresh
 =====================================================
 
 Started: 2026-06-01
-Status: In Progress (1/2 items)
+Status: Complete (2/2 items)
 
 ## Goals
 - Update the website's rounded App Store social-proof count from `100+` to `125+`.
@@ -13,17 +13,17 @@ Status: In Progress (1/2 items)
 
 ### Priority 1
 - [x] REV-001: Update App Store review count messaging
-- [ ] REV-002: Verify build and stale copy removal
+- [x] REV-002: Verify build and stale copy removal
 
 ## Verification Notes
 - `npm ci` was required in the fresh worktree before building.
 - `npm run build` passed.
 - Rendered homepage output contains `125+` public rating copy and JSON-LD `reviewCount` of `126`.
 - Rendered homepage output no longer contains stale `100+ App Store ratings` copy.
+- Final diff review confirmed the only source change is `src/lib/app-store.ts`.
 
 ## Files to Modify
 - src/lib/app-store.ts
-- src/components/AppStoreRatingLink.tsx
 - .claude_tasks/2026-06-01_10-09-03/
 - plans/sprints/2026-06-01-review-count-125/
 

--- a/plans/sprints/2026-06-01-review-count-125/progress.txt
+++ b/plans/sprints/2026-06-01-review-count-125/progress.txt
@@ -2,7 +2,7 @@ Review Count 125 Refresh
 =====================================================
 
 Started: 2026-06-01
-Status: In Progress (0/2 items)
+Status: In Progress (1/2 items)
 
 ## Goals
 - Update the website's rounded App Store social-proof count from `100+` to `125+`.
@@ -12,7 +12,7 @@ Status: In Progress (0/2 items)
 ## Items
 
 ### Priority 1
-- [ ] REV-001: Update App Store review count messaging
+- [x] REV-001: Update App Store review count messaging
 - [ ] REV-002: Verify build and stale copy removal
 
 ## Files to Modify
@@ -34,4 +34,3 @@ RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph.sh plans/sprints/2026-06
 # Single iteration:
 RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph_once.sh plans/sprints/2026-06-01-review-count-125
 ```
-

--- a/plans/sprints/2026-06-01-review-count-125/progress.txt
+++ b/plans/sprints/2026-06-01-review-count-125/progress.txt
@@ -1,0 +1,37 @@
+Review Count 125 Refresh
+=====================================================
+
+Started: 2026-06-01
+Status: In Progress (0/2 items)
+
+## Goals
+- Update the website's rounded App Store social-proof count from `100+` to `125+`.
+- Keep exact structured-data review count aligned with the user-provided current count of 126.
+- Preserve layout, App Store link behavior, and rating value.
+
+## Items
+
+### Priority 1
+- [ ] REV-001: Update App Store review count messaging
+- [ ] REV-002: Verify build and stale copy removal
+
+## Files to Modify
+- src/lib/app-store.ts
+- src/components/AppStoreRatingLink.tsx
+- .claude_tasks/2026-06-01_10-09-03/
+- plans/sprints/2026-06-01-review-count-125/
+
+## Deployment
+- Publish through the normal GitHub PR merge to main.
+- Let Vercel deploy production from the merge commit.
+
+## Ralph Launch Commands
+
+```bash
+# Iterative (runs up to 25 iterations until all items pass):
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph.sh plans/sprints/2026-06-01-review-count-125 25
+
+# Single iteration:
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph_once.sh plans/sprints/2026-06-01-review-count-125
+```
+

--- a/plans/sprints/2026-06-01-review-count-125/prompt.md
+++ b/plans/sprints/2026-06-01-review-count-125/prompt.md
@@ -1,0 +1,30 @@
+# Review Count 125 Refresh Sprint Prompt
+
+Update the website's App Store review/rating count messaging using the user-provided current count.
+
+## Current Truth
+
+- User stated on 2026-06-01 that BarrelBook now has 126 App Store reviews.
+- Public rounded messaging should say `125+`, replacing the stale `100+` claim.
+
+## Implementation Constraints
+
+- Keep the existing App Store URL unchanged.
+- Keep the existing rating value unchanged unless the source code already ties it directly to review-count copy.
+- Keep the existing visual design and layout unchanged.
+- Update centralized constants rather than duplicating copy.
+- If an exact structured-data review count exists, set it to `126`.
+- Do not redesign the hero, rating link, reviews section, or app store badge.
+
+## Verification Commands
+
+```bash
+npm run build
+
+# Confirm refreshed public copy and exact structured data.
+rg "125\\+|reviewCount.*126|APP_STORE_RATING_DISPLAY_COUNT" src .next
+
+# Confirm stale rounded count is gone from App Store rating messaging.
+rg "100\\+ App Store ratings|APP_STORE_RATING_DISPLAY_COUNT = \"100\\+\"" src .next
+```
+

--- a/src/lib/app-store.ts
+++ b/src/lib/app-store.ts
@@ -4,8 +4,9 @@ export const APP_STORE_URL =
   `https://apps.apple.com/us/app/barrelbook-whiskey-catalog/id${APP_STORE_APP_ID}`;
 
 export const APP_STORE_RATING_VALUE = "4.8";
-export const APP_STORE_RATING_COUNT = "116";
-export const APP_STORE_RATING_DISPLAY_COUNT = "100+";
+// REV-001: keep structured data exact while public copy uses a durable rounded count.
+export const APP_STORE_RATING_COUNT = "126";
+export const APP_STORE_RATING_DISPLAY_COUNT = "125+";
 
 export const TESTFLIGHT_URL =
   process.env.BARRELBOOK_TESTFLIGHT_URL?.trim() || "https://testflight.apple.com/";


### PR DESCRIPTION
## Summary
- Update App Store structured-data review count to 126
- Update rounded public App Store rating count to 125+
- Preserve existing App Store URL, rating value, and layout

## Verification
- npm run build
- Rendered homepage contains 125+ public copy
- Rendered JSON-LD contains reviewCount 126
- Stale rendered 100+ App Store ratings copy is absent