### PR TITLE
[codex] Update App Store review count to 135+

### DIFF
--- a/.claude_tasks/2026-06-07_08-07-06/SUMMARY.md
+++ b/.claude_tasks/2026-06-07_08-07-06/SUMMARY.md
@@ -1,0 +1,33 @@
+# Summary
+
+## Files Added / Modified
+
+- `src/lib/app-store.ts`
+- `.claude_tasks/2026-06-07_08-07-06/T1_base_from_origin_main.md`
+- `.claude_tasks/2026-06-07_08-07-06/T2_scaffold_task_and_ralph_logs.md`
+- `.claude_tasks/2026-06-07_08-07-06/T3_update_review_count.md`
+- `.claude_tasks/2026-06-07_08-07-06/T4_verify_rendered_output.md`
+- `.claude_tasks/2026-06-07_08-07-06/T5_commit_scoped_update.md`
+- `.claude_tasks/2026-06-07_08-07-06/SUMMARY.md`
+- `plans/sprints/2026-06-07-update-review-count-135/prd.json`
+- `plans/sprints/2026-06-07-update-review-count-135/progress.txt`
+- `plans/sprints/2026-06-07-update-review-count-135/prompt.md`
+
+## Overview
+
+Updated BarrelBook website App Store social proof from `125+` to `135+` using the centralized constants in `src/lib/app-store.ts`. Structured metadata remains exact with `reviewCount` set to `135`, while public copy and accessibility labels use `135+`.
+
+## Verification
+
+```bash
+npm run build
+rg -o '"reviewCount":"135"|135\+|stars from' .next/server/app/index.html .next/server/app/index.rsc .next/server/app/index.segments
+rg -n '125\+|"reviewCount":"126"|from 125' .next/server/app/index.html .next/server/app/index.rsc .next/server/app/index.segments src
+```
+
+Build passed. The positive rendered-output check found `reviewCount":"135"` and `135+`; the stale-value check returned no matches.
+
+## Next Recommended Steps
+
+- Push the branch and open the normal website PR.
+- Let Vercel build the preview and production deploy after merge.

--- a/.claude_tasks/2026-06-07_08-07-06/T1_base_from_origin_main.md
+++ b/.claude_tasks/2026-06-07_08-07-06/T1_base_from_origin_main.md
@@ -1,0 +1,18 @@
+# Task 1: Base From Origin Main
+
+## Description
+
+Create a clean worktree and branch from `origin/main` so the review-count update is based on the production 125+ implementation rather than the stale local side branch.
+
+## Decisions
+
+- Use branch `codex/update-review-count-135`.
+- Use sibling worktree `/Users/petereilly2021/Projects/barrelbook-website-review-count-135`.
+- Preserve the existing dirty checkout at `/Users/petereilly2021/Projects/barrelbook-website`.
+
+## Evidence
+
+```text
+HEAD is now at 58133e6 Update App Store review count messaging to 125+
+```
+

--- a/.claude_tasks/2026-06-07_08-07-06/T2_scaffold_task_and_ralph_logs.md
+++ b/.claude_tasks/2026-06-07_08-07-06/T2_scaffold_task_and_ralph_logs.md
@@ -1,0 +1,20 @@
+# Task 2: Scaffold Task And Ralph Logs
+
+## Description
+
+Create the required task log folder and Ralph sprint scaffold before implementation.
+
+## Decisions
+
+- Task log folder: `.claude_tasks/2026-06-07_08-07-06/`
+- Ralph sprint folder: `plans/sprints/2026-06-07-update-review-count-135/`
+- Sprint item prefix: `RC135`
+
+## Files
+
+```text
+plans/sprints/2026-06-07-update-review-count-135/prd.json
+plans/sprints/2026-06-07-update-review-count-135/progress.txt
+plans/sprints/2026-06-07-update-review-count-135/prompt.md
+```
+

--- a/.claude_tasks/2026-06-07_08-07-06/T3_update_review_count.md
+++ b/.claude_tasks/2026-06-07_08-07-06/T3_update_review_count.md
@@ -1,0 +1,23 @@
+# Task 3: Update Review Count
+
+## Description
+
+Update the centralized App Store rating constants from the current production values to the new 135+ public messaging.
+
+## Code Snippet
+
+```ts
+// RC135-003: keep structured data exact while public copy uses a durable rounded count.
+export const APP_STORE_RATING_COUNT = "135";
+export const APP_STORE_RATING_DISPLAY_COUNT = "135+";
+```
+
+## Decisions
+
+- Keep `APP_STORE_RATING_COUNT` numeric for structured data.
+- Keep `APP_STORE_RATING_DISPLAY_COUNT` rounded for public copy and accessibility text.
+- Leave `APP_STORE_RATING_VALUE` unchanged unless verification reveals it has changed.
+
+## Result
+
+Updated `src/lib/app-store.ts` so the website renders `135+` in public copy and `135` in structured data.

--- a/.claude_tasks/2026-06-07_08-07-06/T4_verify_rendered_output.md
+++ b/.claude_tasks/2026-06-07_08-07-06/T4_verify_rendered_output.md
@@ -1,0 +1,32 @@
+# Task 4: Verify Rendered Output
+
+## Description
+
+Run the project build and inspect the output path usage so visible copy and JSON-LD remain consistent.
+
+## Verification Commands
+
+```bash
+npm run build
+rg -n "135\\+|reviewCount|APP_STORE_RATING" src .next/server/app
+```
+
+## Decisions
+
+- Use `npm run build` as the primary website verification command.
+- Inspect source and generated server output for both visible copy and structured metadata.
+
+## Result
+
+```text
+npm run build
+✓ Compiled successfully
+✓ Generating static pages using 17 workers (22/22)
+```
+
+```text
+.next/server/app/index.html:"reviewCount":"135"
+.next/server/app/index.html:135+
+```
+
+No stale `125+`, `"reviewCount":"126"`, or `from 125` matches remain in `src` or the generated homepage artifacts.

--- a/.claude_tasks/2026-06-07_08-07-06/T5_commit_scoped_update.md
+++ b/.claude_tasks/2026-06-07_08-07-06/T5_commit_scoped_update.md
@@ -1,0 +1,20 @@
+# Task 5: Commit Scoped Update
+
+## Description
+
+Review the diff, stage only the review-count/task-scaffold files, and commit the scoped update.
+
+## Decisions
+
+- Do not include unrelated files from the original dirty checkout.
+- Commit message should describe the user-facing update.
+
+## Result
+
+Prepared a scoped commit containing:
+
+- `src/lib/app-store.ts`
+- `.claude_tasks/2026-06-07_08-07-06/`
+- `plans/sprints/2026-06-07-update-review-count-135/`
+
+Ignored build/dependency artifacts from local verification.

--- a/plans/sprints/2026-06-07-update-review-count-135/prd.json
+++ b/plans/sprints/2026-06-07-update-review-count-135/prd.json
@@ -1,0 +1,101 @@
+{
+  "project": {
+    "name": "Update Review Count To 135+",
+    "repoRoot": "."
+  },
+  "definitionOfDone": {
+    "required": [
+      "All items pass",
+      "Project builds",
+      "No regressions"
+    ]
+  },
+  "files_changed": [
+    "src/lib/app-store.ts",
+    ".claude_tasks/2026-06-07_08-07-06/",
+    "plans/sprints/2026-06-07-update-review-count-135/"
+  ],
+  "items": [
+    {
+      "id": "RC135-001",
+      "priority": 1,
+      "title": "Base update on production main",
+      "description": "Perform the update in a clean branch/worktree based on origin/main so the current production 125+ implementation is preserved and updated.",
+      "acceptanceCriteria": [
+        "Worktree is on branch codex/update-review-count-135",
+        "Branch is based on origin/main at or after commit 58133e6",
+        "Original dirty checkout is not modified"
+      ],
+      "passes": true,
+      "tags": [
+        "git",
+        "setup"
+      ]
+    },
+    {
+      "id": "RC135-002",
+      "priority": 1,
+      "title": "Scaffold task tracking",
+      "description": "Create the required .claude_tasks task log and Ralph sprint files before implementation begins.",
+      "acceptanceCriteria": [
+        ".claude_tasks/2026-06-07_08-07-06/ exists with one markdown file per task",
+        "plans/sprints/2026-06-07-update-review-count-135/prd.json exists and follows plans/prd.schema.json",
+        "plans/sprints/2026-06-07-update-review-count-135/progress.txt exists",
+        "plans/sprints/2026-06-07-update-review-count-135/prompt.md exists"
+      ],
+      "passes": true,
+      "tags": [
+        "tracking",
+        "ralph"
+      ]
+    },
+    {
+      "id": "RC135-003",
+      "priority": 1,
+      "title": "Update App Store review count constants",
+      "description": "Update the centralized App Store rating constants so public copy displays 135+ while structured data keeps an exact numeric review count.",
+      "acceptanceCriteria": [
+        "APP_STORE_RATING_COUNT is 135",
+        "APP_STORE_RATING_DISPLAY_COUNT is 135+",
+        "APP_STORE_RATING_VALUE remains 4.8 unless separately verified as changed",
+        "No unrelated marketing copy is changed"
+      ],
+      "passes": true,
+      "tags": [
+        "copy",
+        "seo"
+      ]
+    },
+    {
+      "id": "RC135-004",
+      "priority": 2,
+      "title": "Verify build and rendered count usage",
+      "description": "Run the website build and inspect source/generated output to confirm visible copy and JSON-LD use the expected values.",
+      "acceptanceCriteria": [
+        "npm run build passes",
+        "Rendered or generated output contains 135+ for public-facing rating copy",
+        "Structured data reviewCount uses 135",
+        "No stale 125+ App Store rating copy remains in rendered homepage output"
+      ],
+      "passes": true,
+      "tags": [
+        "verification"
+      ]
+    },
+    {
+      "id": "RC135-005",
+      "priority": 3,
+      "title": "Commit scoped update",
+      "description": "Stage and commit only the review-count update plus required task/sprint tracking artifacts.",
+      "acceptanceCriteria": [
+        "git diff is limited to src/lib/app-store.ts and required task/sprint files",
+        "Changes are committed on codex/update-review-count-135",
+        "Commit message describes the 135+ review-count update"
+      ],
+      "passes": true,
+      "tags": [
+        "git"
+      ]
+    }
+  ]
+}

--- a/plans/sprints/2026-06-07-update-review-count-135/progress.txt
+++ b/plans/sprints/2026-06-07-update-review-count-135/progress.txt
@@ -1,0 +1,31 @@
+Update Review Count To 135+
+=====================================================
+
+Started: 2026-06-07
+Status: Complete (5/5 items)
+
+## Goals
+- Update BarrelBook website review-count messaging from 125+ to 135+.
+- Keep structured metadata exact and public copy rounded.
+- Preserve unrelated local work by using a clean origin/main worktree.
+
+## Items
+
+### Priority 1
+- [x] RC135-001: Base update on production main
+- [x] RC135-002: Scaffold task tracking
+- [x] RC135-003: Update App Store review count constants
+
+### Priority 2
+- [x] RC135-004: Verify build and rendered count usage
+
+### Priority 3
+- [x] RC135-005: Commit scoped update
+
+## Files to Modify
+- src/lib/app-store.ts
+- .claude_tasks/2026-06-07_08-07-06/
+- plans/sprints/2026-06-07-update-review-count-135/
+
+## Deployment
+- Website deploy should follow the normal Vercel/GitHub flow after review or merge.

--- a/plans/sprints/2026-06-07-update-review-count-135/prompt.md
+++ b/plans/sprints/2026-06-07-update-review-count-135/prompt.md
@@ -1,0 +1,46 @@
+# RALPH Sprint: Update Review Count To 135+
+
+You are RALPH, an autonomous implementation agent working through this small BarrelBook website sprint. Follow the generic RALPH protocol in `plans/ralph_prompt.md`, with the sprint-specific rules below.
+
+## Context
+
+The production website currently shows `4.8 stars from 125+ App Store ratings`. `origin/main` centralizes this in `src/lib/app-store.ts`:
+
+```ts
+export const APP_STORE_RATING_COUNT = "126";
+export const APP_STORE_RATING_DISPLAY_COUNT = "125+";
+```
+
+Update the public-facing count to `135+` while keeping JSON-LD structured data numeric.
+
+## Verification Commands
+
+```bash
+npm run build
+rg -n "135\\+|reviewCount|APP_STORE_RATING" src .next/server/app
+```
+
+## Domain-Specific Guidelines
+
+- Preserve `APP_STORE_RATING_VALUE = "4.8"` unless separately verified as changed.
+- Keep `APP_STORE_RATING_COUNT` exact and numeric for structured data.
+- Keep `APP_STORE_RATING_DISPLAY_COUNT` rounded for visible copy and aria labels.
+- Do not touch unrelated homepage, ad, promo, or deep-link content.
+- Do not commit secrets or environment files.
+
+## Constraints
+
+- Work must stay on `codex/update-review-count-135`.
+- The original checkout at `/Users/petereilly2021/Projects/barrelbook-website` has unrelated state and should remain untouched.
+- This is a production copy update, so prefer the smallest diff.
+
+## Launch Commands
+
+```bash
+# Iterative (runs up to 25 iterations until all items pass):
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph.sh plans/sprints/2026-06-07-update-review-count-135 25
+
+# Single iteration:
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph_once.sh plans/sprints/2026-06-07-update-review-count-135
+```
+

--- a/src/lib/app-store.ts
+++ b/src/lib/app-store.ts
@@ -4,9 +4,9 @@ export const APP_STORE_URL =
   `https://apps.apple.com/us/app/barrelbook-whiskey-catalog/id${APP_STORE_APP_ID}`;
 
 export const APP_STORE_RATING_VALUE = "4.8";
-// REV-001: keep structured data exact while public copy uses a durable rounded count.
-export const APP_STORE_RATING_COUNT = "126";
-export const APP_STORE_RATING_DISPLAY_COUNT = "125+";
+// RC135-003: keep structured data exact while public copy uses a durable rounded count.
+export const APP_STORE_RATING_COUNT = "135";
+export const APP_STORE_RATING_DISPLAY_COUNT = "135+";
 
 export const TESTFLIGHT_URL =
   process.env.BARRELBOOK_TESTFLIGHT_URL?.trim() || "https://testflight.apple.com/";


### PR DESCRIPTION
## Summary

- Updates the centralized App Store review-count constants from exact `126` / display `125+` to exact `135` / display `135+`.
- Keeps JSON-LD structured data numeric while public copy and aria labels use the rounded `135+` display count.
- Adds the required task log and Ralph sprint scaffold for this production copy update.

## Verification

- `npm run build`
- Generated homepage output contains `"reviewCount":"135"` and `135+`.
- Stale-value check found no `125+`, `"reviewCount":"126"`, or `from 125` matches in `src` or generated homepage artifacts.

## Notes

Production will remain at `125+` until this PR is merged and Vercel deploys the change.