### PR TITLE
[codex] Add June 2026 App Store reviews

### DIFF
--- a/.claude_tasks/2026-06-09_20-12-21/SUMMARY.md
+++ b/.claude_tasks/2026-06-09_20-12-21/SUMMARY.md
@@ -1,0 +1,35 @@
+# Summary
+
+## Files Added / Modified
+
+- `src/components/LandingPage.tsx`
+- `src/lib/app-store.ts`
+- `.claude_tasks/2026-06-09_20-12-21/T1_base_from_origin_main.md`
+- `.claude_tasks/2026-06-09_20-12-21/T2_scaffold_task_and_ralph_logs.md`
+- `.claude_tasks/2026-06-09_20-12-21/T3_add_june_reviews.md`
+- `.claude_tasks/2026-06-09_20-12-21/T4_update_review_count.md`
+- `.claude_tasks/2026-06-09_20-12-21/T5_verify_rendered_output.md`
+- `.claude_tasks/2026-06-09_20-12-21/T6_commit_scoped_update.md`
+- `.claude_tasks/2026-06-09_20-12-21/SUMMARY.md`
+- `plans/sprints/2026-06-09-add-june-2026-reviews/prd.json`
+- `plans/sprints/2026-06-09-add-june-2026-reviews/progress.txt`
+- `plans/sprints/2026-06-09-add-june-2026-reviews/prompt.md`
+
+## Overview
+
+Added two June 2026 App Store reviews to the homepage review grid in newest-first order. The longer JackD_942 review uses a homepage-friendly excerpt, and the Djbindust review is kept close to the supplied text. Review footer rendering now handles reviews without an app version.
+
+Updated exact structured App Store review metadata from `135` to `137` while leaving public rounded copy as `135+`.
+
+## Verification
+
+```bash
+npm run build
+```
+
+Build passed. Generated homepage output contains `JackD_942`, `Djbindust`, `"reviewCount":"137"`, and `135+`. No `vundefined` footer text appears.
+
+## Next Recommended Steps
+
+- Push the branch and open the normal website PR.
+- Let Vercel build the preview and production deploy after merge.

--- a/.claude_tasks/2026-06-09_20-12-21/T1_base_from_origin_main.md
+++ b/.claude_tasks/2026-06-09_20-12-21/T1_base_from_origin_main.md
@@ -1,0 +1,18 @@
+# Task 1: Base From Origin Main
+
+## Description
+
+Create a clean branch/worktree from `origin/main` so the review update starts from current production code instead of the stale dirty checkout.
+
+## Decisions
+
+- Branch: `codex/add-june-2026-app-store-reviews`
+- Worktree: `/Users/petereilly2021/Projects/barrelbook-website-june-2026-reviews`
+- Base commit: `d6a7047 OMV-005: prepare shareable deployment`
+
+## Result
+
+```text
+HEAD is now at d6a7047 OMV-005: prepare shareable deployment
+```
+

--- a/.claude_tasks/2026-06-09_20-12-21/T2_scaffold_task_and_ralph_logs.md
+++ b/.claude_tasks/2026-06-09_20-12-21/T2_scaffold_task_and_ralph_logs.md
@@ -1,0 +1,20 @@
+# Task 2: Scaffold Task And Ralph Logs
+
+## Description
+
+Create the required task log and Ralph sprint scaffold before implementation begins.
+
+## Decisions
+
+- Task log folder: `.claude_tasks/2026-06-09_20-12-21/`
+- Ralph sprint folder: `plans/sprints/2026-06-09-add-june-2026-reviews/`
+- Sprint prefix: `JREV`
+
+## Files
+
+```text
+plans/sprints/2026-06-09-add-june-2026-reviews/prd.json
+plans/sprints/2026-06-09-add-june-2026-reviews/progress.txt
+plans/sprints/2026-06-09-add-june-2026-reviews/prompt.md
+```
+

--- a/.claude_tasks/2026-06-09_20-12-21/T3_add_june_reviews.md
+++ b/.claude_tasks/2026-06-09_20-12-21/T3_add_june_reviews.md
@@ -1,0 +1,29 @@
+# Task 3: Add June Reviews
+
+## Description
+
+Add the two supplied App Store reviews to the homepage review grid, ordered newest-first.
+
+## Decisions
+
+- Add JackD_942 first because it is dated June 8, 2026.
+- Add Djbindust second because it is dated June 3, 2026.
+- Use a curated excerpt for the long JackD_942 review so the homepage grid stays scannable.
+- Keep the shorter Djbindust review close to verbatim.
+- Make `version` optional in the review footer because the screenshots do not show app versions.
+
+## Planned Review Snippets
+
+```text
+BarrelBook Is the Whiskey Collection Tool I Didn't Know I Needed
+JackD_942, Jun 8, 2026
+```
+
+```text
+Well Thought Out
+Djbindust, Jun 3, 2026
+```
+
+## Result
+
+Added both reviews to `src/components/LandingPage.tsx` at the top of the homepage review grid. The JackD_942 review uses a curated excerpt focused on collection tracking, palate understanding, shelf management, and overall recommendation. The review footer now omits app version text when a review has no version supplied.

--- a/.claude_tasks/2026-06-09_20-12-21/T4_update_review_count.md
+++ b/.claude_tasks/2026-06-09_20-12-21/T4_update_review_count.md
@@ -1,0 +1,15 @@
+# Task 4: Update Review Count
+
+## Description
+
+Update exact structured review count for the two new reviews while preserving the public rounded `135+` display.
+
+## Decision
+
+- Change `APP_STORE_RATING_COUNT` from `135` to `137`.
+- Leave `APP_STORE_RATING_DISPLAY_COUNT` as `135+`.
+- Leave `APP_STORE_RATING_VALUE` as `4.8`.
+
+## Result
+
+Updated `src/lib/app-store.ts` so JSON-LD uses exact `reviewCount` 137 while public social-proof copy remains `135+`.

--- a/.claude_tasks/2026-06-09_20-12-21/T5_verify_rendered_output.md
+++ b/.claude_tasks/2026-06-09_20-12-21/T5_verify_rendered_output.md
@@ -1,0 +1,32 @@
+# Task 5: Verify Rendered Output
+
+## Description
+
+Build the site and inspect generated homepage output for the new reviews and structured review count.
+
+## Verification Commands
+
+```bash
+npm run build
+rg -n "JackD_942|Djbindust|reviewCount|137|135\\+" src .next/server/app/index.html .next/server/app/index.rsc .next/server/app/index.segments
+```
+
+## Result
+
+```text
+npm run build
+✓ Compiled successfully
+✓ Generating static pages using 17 workers (22/22)
+```
+
+Generated homepage output contains:
+
+```text
+"reviewCount":"137"
+135+
+JackD_942
+Djbindust
+Cewj2000
+```
+
+Ordering check passed: `JackD_942` appears before `Djbindust`, and `Djbindust` appears before the previous first review, `Cewj2000`. No `vundefined` footer text appears in generated homepage output.

--- a/.claude_tasks/2026-06-09_20-12-21/T6_commit_scoped_update.md
+++ b/.claude_tasks/2026-06-09_20-12-21/T6_commit_scoped_update.md
@@ -1,0 +1,21 @@
+# Task 6: Commit Scoped Update
+
+## Description
+
+Review the diff, stage only the review update and required task/sprint files, then commit the scoped change.
+
+## Decisions
+
+- Do not include build output or dependency folders.
+- Keep the commit focused on homepage review additions, count metadata, and required task records.
+
+## Result
+
+Prepared a scoped commit containing:
+
+- `src/components/LandingPage.tsx`
+- `src/lib/app-store.ts`
+- `.claude_tasks/2026-06-09_20-12-21/`
+- `plans/sprints/2026-06-09-add-june-2026-reviews/`
+
+Ignored local verification artifacts from `.next/`, `node_modules/`, and `next-env.d.ts`.

--- a/plans/sprints/2026-06-09-add-june-2026-reviews/prd.json
+++ b/plans/sprints/2026-06-09-add-june-2026-reviews/prd.json
@@ -1,0 +1,119 @@
+{
+  "project": {
+    "name": "Add June 2026 App Store Reviews",
+    "repoRoot": "."
+  },
+  "definitionOfDone": {
+    "required": [
+      "All items pass",
+      "Project builds",
+      "No regressions"
+    ]
+  },
+  "files_changed": [
+    "src/components/LandingPage.tsx",
+    "src/lib/app-store.ts",
+    ".claude_tasks/2026-06-09_20-12-21/",
+    "plans/sprints/2026-06-09-add-june-2026-reviews/"
+  ],
+  "items": [
+    {
+      "id": "JREV-001",
+      "priority": 1,
+      "title": "Base update on origin main",
+      "description": "Perform the review update in a clean branch/worktree based on origin/main so unrelated local state is preserved.",
+      "acceptanceCriteria": [
+        "Worktree is on branch codex/add-june-2026-app-store-reviews",
+        "Branch is based on origin/main at or after commit d6a7047",
+        "Original dirty checkout is not modified"
+      ],
+      "passes": true,
+      "tags": [
+        "git",
+        "setup"
+      ]
+    },
+    {
+      "id": "JREV-002",
+      "priority": 1,
+      "title": "Scaffold task tracking",
+      "description": "Create the required .claude_tasks task log and Ralph sprint files before implementation begins.",
+      "acceptanceCriteria": [
+        ".claude_tasks/2026-06-09_20-12-21/ exists with one markdown file per task",
+        "plans/sprints/2026-06-09-add-june-2026-reviews/prd.json exists and follows plans/prd.schema.json",
+        "plans/sprints/2026-06-09-add-june-2026-reviews/progress.txt exists",
+        "plans/sprints/2026-06-09-add-june-2026-reviews/prompt.md exists"
+      ],
+      "passes": true,
+      "tags": [
+        "tracking",
+        "ralph"
+      ]
+    },
+    {
+      "id": "JREV-003",
+      "priority": 1,
+      "title": "Add June App Store reviews to homepage",
+      "description": "Add the supplied June 2026 App Store reviews to the homepage review grid in newest-first order.",
+      "acceptanceCriteria": [
+        "JackD_942 review appears first in the homepage review grid",
+        "Djbindust review appears second in the homepage review grid",
+        "The long JackD_942 review is excerpted for homepage readability",
+        "Review footer handles missing version without rendering an undefined value",
+        "Existing reviews remain present"
+      ],
+      "passes": true,
+      "tags": [
+        "copy",
+        "reviews"
+      ]
+    },
+    {
+      "id": "JREV-004",
+      "priority": 1,
+      "title": "Update exact structured review count",
+      "description": "Increment exact App Store review count metadata for the two new reviews while preserving rounded public display copy.",
+      "acceptanceCriteria": [
+        "APP_STORE_RATING_COUNT is 137",
+        "APP_STORE_RATING_DISPLAY_COUNT remains 135+",
+        "APP_STORE_RATING_VALUE remains 4.8"
+      ],
+      "passes": true,
+      "tags": [
+        "seo",
+        "metadata"
+      ]
+    },
+    {
+      "id": "JREV-005",
+      "priority": 2,
+      "title": "Verify build and rendered output",
+      "description": "Run the website build and inspect generated homepage output for the new reviews and updated structured review count.",
+      "acceptanceCriteria": [
+        "npm run build passes",
+        "Generated homepage output contains JackD_942 and Djbindust",
+        "Generated homepage output contains structured reviewCount 137",
+        "Generated homepage output still contains public display count 135+"
+      ],
+      "passes": true,
+      "tags": [
+        "verification"
+      ]
+    },
+    {
+      "id": "JREV-006",
+      "priority": 3,
+      "title": "Commit scoped update",
+      "description": "Stage and commit only the review update plus required task/sprint tracking artifacts.",
+      "acceptanceCriteria": [
+        "git diff is limited to homepage review data, app-store metadata, and required task/sprint files",
+        "Changes are committed on codex/add-june-2026-app-store-reviews",
+        "Commit message describes the June review additions"
+      ],
+      "passes": true,
+      "tags": [
+        "git"
+      ]
+    }
+  ]
+}

--- a/plans/sprints/2026-06-09-add-june-2026-reviews/progress.txt
+++ b/plans/sprints/2026-06-09-add-june-2026-reviews/progress.txt
@@ -1,0 +1,33 @@
+Add June 2026 App Store Reviews
+=====================================================
+
+Started: 2026-06-09
+Status: Complete (6/6 items)
+
+## Goals
+- Add two new App Store reviews to the BarrelBook homepage.
+- Keep the homepage review grid readable with a curated excerpt for the long review.
+- Keep structured review metadata current without changing rounded public count copy.
+
+## Items
+
+### Priority 1
+- [x] JREV-001: Base update on origin main
+- [x] JREV-002: Scaffold task tracking
+- [x] JREV-003: Add June App Store reviews to homepage
+- [x] JREV-004: Update exact structured review count
+
+### Priority 2
+- [x] JREV-005: Verify build and rendered output
+
+### Priority 3
+- [x] JREV-006: Commit scoped update
+
+## Files to Modify
+- src/components/LandingPage.tsx
+- src/lib/app-store.ts
+- .claude_tasks/2026-06-09_20-12-21/
+- plans/sprints/2026-06-09-add-june-2026-reviews/
+
+## Deployment
+- Website deploy should follow the normal GitHub/Vercel flow after review or merge.

--- a/plans/sprints/2026-06-09-add-june-2026-reviews/prompt.md
+++ b/plans/sprints/2026-06-09-add-june-2026-reviews/prompt.md
@@ -1,0 +1,47 @@
+# RALPH Sprint: Add June 2026 App Store Reviews
+
+You are RALPH, an autonomous implementation agent working through this small BarrelBook website sprint. Follow the generic RALPH protocol in `plans/ralph_prompt.md`, with the sprint-specific rules below.
+
+## Context
+
+The homepage App Store review grid lives inline in `src/components/LandingPage.tsx`. The App Store rating metadata lives in `src/lib/app-store.ts`.
+
+Two new App Store reviews should be added:
+
+- `JackD_942`, June 8, 2026, title `BarrelBook Is the Whiskey Collection Tool I Didn't Know I Needed`
+- `Djbindust`, June 3, 2026, title `Well Thought Out`
+
+The JackD_942 body is long. Use a homepage-friendly excerpt that preserves the core value: collection tracking, palate understanding, shelf management, and overall recommendation. Avoid foregrounding experimental MCP access in the homepage review grid.
+
+## Verification Commands
+
+```bash
+npm run build
+rg -n "JackD_942|Djbindust|reviewCount|137|135\\+" src .next/server/app/index.html .next/server/app/index.rsc .next/server/app/index.segments
+```
+
+## Domain-Specific Guidelines
+
+- Put the newest reviews first.
+- Preserve existing review cards unless directly necessary.
+- Make the footer robust for reviews where no app version is supplied.
+- Keep `APP_STORE_RATING_DISPLAY_COUNT` as `135+`.
+- Update exact `APP_STORE_RATING_COUNT` to `137`.
+- Do not touch unrelated promo, deep-link, ad, video, or app-store badge code.
+
+## Constraints
+
+- Work must stay on `codex/add-june-2026-app-store-reviews`.
+- The original checkout at `/Users/petereilly2021/Projects/barrelbook-website` has unrelated state and should remain untouched.
+- This is a production copy update, so prefer the smallest diff.
+
+## Launch Commands
+
+```bash
+# Iterative (runs up to 25 iterations until all items pass):
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph.sh plans/sprints/2026-06-09-add-june-2026-reviews 25
+
+# Single iteration:
+RALPH_AGENT_CMD=./plans/adapters/Codex.sh ./plans/ralph_once.sh plans/sprints/2026-06-09-add-june-2026-reviews
+```
+

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -345,6 +345,19 @@ export default function LandingPage() {
 
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
             {[
+              // JREV-003: newest App Store reviews first; the longer June 8 review uses a homepage-friendly excerpt.
+              {
+                title: "BarrelBook Is the Whiskey Collection Tool I Didn’t Know I Needed",
+                text: "BarrelBook has quickly become one of the most useful tools in my whiskey journey. It goes beyond simply tracking bottles — it helps me understand my collection, my palate, and the role each bottle plays on my shelf. Overall, BarrelBook is one of the best bourbon and whiskey collection tools I’ve used.",
+                author: "JackD_942",
+                date: "Jun 8, 2026",
+              },
+              {
+                title: "Well Thought Out",
+                text: "Wow, this is such a well thought out App. The AI image recognition takes it to the next level. The “Tonight’s Pour” or “Wheel of Bourbon” is a fun feature. The “Bourbon Somelier” lets a newbie look like a professional. 👍",
+                author: "Djbindust",
+                date: "Jun 3, 2026",
+              },
               {
                 title: "This app makes my hobby more organized.",
                 text: "This app has made my bottle tracking so much easier. I hated going to a store and not being sure if I already had a bottle or not. Now with BarrelBook I can simply open the app and compare my collection to what is available on the shelves. I do also love that I can share my collection with my friends. It makes bottle shares so much more fun as we can look at what is potentially available to share.",
@@ -422,7 +435,7 @@ export default function LandingPage() {
                 <p className="text-gray-300 text-base mb-4 flex-1">{review.text}</p>
                 <div className="flex items-center justify-between text-xs text-gray-500">
                   <span>{review.author}</span>
-                  <span>{review.date} · v{review.version}</span>
+                  <span>{review.version ? `${review.date} · v${review.version}` : review.date}</span>
                 </div>
               </div>
             ))}

--- a/src/lib/app-store.ts
+++ b/src/lib/app-store.ts
@@ -4,8 +4,8 @@ export const APP_STORE_URL =
   `https://apps.apple.com/us/app/barrelbook-whiskey-catalog/id${APP_STORE_APP_ID}`;
 
 export const APP_STORE_RATING_VALUE = "4.8";
-// RC135-003: keep structured data exact while public copy uses a durable rounded count.
-export const APP_STORE_RATING_COUNT = "135";
+// JREV-004: keep structured data exact while public copy uses a durable rounded count.
+export const APP_STORE_RATING_COUNT = "137";
 export const APP_STORE_RATING_DISPLAY_COUNT = "135+";
 
 export const TESTFLIGHT_URL =


### PR DESCRIPTION
## Summary

- Adds two June 2026 App Store reviews to the homepage review grid, newest first.
- Uses a homepage-friendly excerpt for the longer JackD_942 review and keeps the Djbindust review close to the supplied text.
- Makes review version display optional so reviews without a supplied app version do not render `vundefined`.
- Updates exact JSON-LD review count from `135` to `137` while keeping public social-proof display at `135+`.

## Verification

- `npm run build`
- Generated homepage output contains `JackD_942`, `Djbindust`, `"reviewCount":"137"`, and `135+`.
- Generated homepage output has no `vundefined` footer text.