### PR TITLE
PWLS-004: add public Want-list page

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,23 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        source: "/w/:path*",
+        headers: [
+          {
+            key: "Referrer-Policy",
+            value: "no-referrer",
+          },
+          {
+            key: "X-Robots-Tag",
+            value: "noindex, nofollow, noarchive",
+          },
+          {
+            key: "Cache-Control",
+            value: "no-store",
+          },
+        ],
+      },
+      {
         source: "/openai-approval/:path*",
         headers: [
           {

--- a/plans/sprints/2026-06-14-public-want-list-empty-state/SUMMARY.md
+++ b/plans/sprints/2026-06-14-public-want-list-empty-state/SUMMARY.md
@@ -1,0 +1,29 @@
+# Public Want List Empty State
+
+## Overview
+
+Fixed the public Want-list page so valid active shares with zero recipient-visible bottles render as active empty lists instead of the neutral unavailable page.
+
+## Files Changed
+
+- `src/app/w/[token]/page.tsx`
+- `plans/sprints/2026-06-14-public-want-list-empty-state/prd.json`
+- `plans/sprints/2026-06-14-public-want-list-empty-state/progress.txt`
+- `plans/sprints/2026-06-14-public-want-list-empty-state/prompt.md`
+
+## Outcome
+
+- Active shares with `items: []` now show list title, description, metadata, and a public empty state.
+- Invalid, revoked, expired, and unavailable responses still use the existing neutral unavailable page.
+- No public endpoint contract changes were made.
+
+## Verification
+
+- `git diff --check`
+- `jq -e . plans/sprints/2026-06-14-public-want-list-empty-state/prd.json`
+- `npm run build`
+- Local browser smoke at `http://localhost:3042/w/NFBIxzxgQ3Ki53fWg1hJ5M1scE2urfCVjVK3SGo7iE8`
+
+## Deployment
+
+Requires website production deploy before `https://www.barrelbook.app/w/NFBIxzxgQ3Ki53fWg1hJ5M1scE2urfCVjVK3SGo7iE8` reflects this fix.

--- a/plans/sprints/2026-06-14-public-want-list-empty-state/prd.json
+++ b/plans/sprints/2026-06-14-public-want-list-empty-state/prd.json
@@ -1,0 +1,35 @@
+{
+  "project": {
+    "name": "Public Want List Empty State",
+    "repoRoot": "."
+  },
+  "files_changed": [
+    "src/app/w/[token]/page.tsx"
+  ],
+  "definitionOfDone": {
+    "required": [
+      "Active public Want-list shares render even when they have zero public items",
+      "Unavailable/revoked/invalid tokens still render the neutral unavailable page",
+      "The page keeps no-store/noindex behavior",
+      "Website build passes",
+      "The reported production token can be verified against the fixed rendering path before deployment"
+    ]
+  },
+  "items": [
+    {
+      "id": "PLES-001",
+      "priority": 1,
+      "title": "Render active empty public Want lists",
+      "description": "The public page should distinguish a valid active share with no recipient-visible items from an invalid, revoked, expired, or mistyped token.",
+      "acceptanceCriteria": [
+        "Parser returns an active snapshot when backend status is active and items is an empty array",
+        "Active empty snapshots show list title, description, metadata, and an empty-state message",
+        "Invalid/revoked/unavailable responses continue to show the existing unavailable page",
+        "No public endpoint contract or analytics behavior changes are introduced",
+        "npm run build passes"
+      ],
+      "passes": true,
+      "tags": ["website", "public-share", "hotfix"]
+    }
+  ]
+}

--- a/plans/sprints/2026-06-14-public-want-list-empty-state/progress.txt
+++ b/plans/sprints/2026-06-14-public-want-list-empty-state/progress.txt
@@ -1,0 +1,44 @@
+Public Want List Empty State
+=====================================================
+
+Started: 2026-06-14
+Status: Complete (1/1 items)
+Branch: codex/public-want-list-page
+Base commit: 5fd4997
+
+## Goals
+- Treat valid active public shares with zero visible items as active, not unavailable.
+- Preserve the neutral unavailable page for invalid, revoked, expired, or mistyped links.
+
+## Items
+
+### Priority 1
+- [x] PLES-001: Render active empty public Want lists
+
+## Files to Modify
+- src/app/w/[token]/page.tsx
+
+## Verification
+- npm run build
+- Read-only production Function canary for token NFBIxzxgQ3Ki53fWg1hJ5M1scE2urfCVjVK3SGo7iE8
+- Local or static verification that active empty snapshots render the empty state
+
+## Deployment
+- Requires a website production deploy after merge/push for https://www.barrelbook.app/w/{token} to show the fixed state.
+
+## Completion Evidence
+- Removed the parser behavior that converted active snapshots with zero public items into unavailable snapshots.
+- Added an active empty-list state for valid public Want-list links with no recipient-visible bottles.
+- Verified the reported token directly against production Functions:
+  - token `NFBIxzxgQ3Ki53fWg1hJ5M1scE2urfCVjVK3SGo7iE8`
+  - Function returned `status: active`, `listName: Want it`, `listDescription: Fathers Day ideas`, and `items: []`.
+- Verification passed:
+  - git diff --check
+  - jq -e . plans/sprints/2026-06-14-public-want-list-empty-state/prd.json
+  - npm run build
+  - Local browser smoke at `http://localhost:3042/w/NFBIxzxgQ3Ki53fWg1hJ5M1scE2urfCVjVK3SGo7iE8`
+- Local browser smoke confirmed:
+  - `Want it` rendered.
+  - `Fathers Day ideas` rendered.
+  - `No public bottles yet` empty state rendered.
+  - `This shared list is unavailable.` did not render.

--- a/plans/sprints/2026-06-14-public-want-list-empty-state/prompt.md
+++ b/plans/sprints/2026-06-14-public-want-list-empty-state/prompt.md
@@ -1,0 +1,30 @@
+# Public Want List Empty State
+
+## Objective
+
+Fix the public Want-list page so valid active shares with zero recipient-visible items render as active empty lists instead of the neutral unavailable page.
+
+## Scope
+
+- Update `src/app/w/[token]/page.tsx` parsing/rendering only.
+- Preserve invalid/revoked/unavailable behavior.
+- Keep no-store/noindex behavior unchanged.
+- Do not change the public Cloud Function contract.
+
+## Verification Commands
+
+```sh
+npm run build
+```
+
+## Constraints
+
+- Public links remain bearer-access and no-login viewable.
+- The website must not reveal whether invalid tokens exist.
+- Empty active shares may display the list title and description because the backend already returned a valid active snapshot for the bearer token.
+
+## Git Hygiene Checklist
+
+- Run `git status --short --branch` before starting and before completion.
+- Use path-scoped staging only if staging is explicitly approved.
+- Do not push, merge, rebase, reset, or deploy production without explicit approval.

--- a/plans/sprints/2026-06-20-public-want-list-mobile-preview/SUMMARY.md
+++ b/plans/sprints/2026-06-20-public-want-list-mobile-preview/SUMMARY.md
@@ -1,0 +1,31 @@
+# Public Want List Mobile Preview Summary
+
+## Files Modified
+- `src/app/w/[token]/page.tsx`
+
+## Overview
+- Tightened mobile spacing for public Want-list item cards.
+- Changed mobile cards to a compact row layout with smaller artwork.
+- Removed brand/type from the visible card metadata while keeping the backend response parsing intact.
+- Kept public notes under the bottle name.
+- Moved target price into a compact right-side mobile tile.
+- Vertically centered the bottle info stack against the artwork and target tile.
+- Moved rank into a larger dedicated left column before the artwork.
+- Rendered optional `ownerDisplayName` in the page eyebrow with a fallback to `Shared Want List`.
+- Preserved the richer desktop card layout.
+
+## Verification
+- `npm run build` passed.
+- Local HTML check confirmed the old `1792 • Bourbon` metadata line is absent while public note and target content still render.
+- Comment-width screenshot captured at `output/playwright/public-want-comment-width-centered.png`.
+- Left-rank variant screenshot captured at `output/playwright/public-want-comment-width-left-rank-large.png`.
+- Owner-name preview screenshot captured at `output/playwright/public-want-owner-name-preview.png`.
+- Local mock preview served at `http://127.0.0.1:3044/w/preview-token`.
+- Screenshots captured:
+  - `output/playwright/public-want-mobile-preview.png`
+  - `output/playwright/public-want-comment-width-preview.png`
+  - `output/playwright/public-want-desktop-preview.png`
+
+## Next Steps
+- Review the preview visually.
+- If approved, commit the website presentation patch.

--- a/plans/sprints/2026-06-20-public-want-list-mobile-preview/SUMMARY.md
+++ b/plans/sprints/2026-06-20-public-want-list-mobile-preview/SUMMARY.md
@@ -27,5 +27,4 @@
   - `output/playwright/public-want-desktop-preview.png`
 
 ## Next Steps
-- Review the preview visually.
-- If approved, commit the website presentation patch.
+- Monitor the production public Want-list page during QA.

--- a/plans/sprints/2026-06-20-public-want-list-mobile-preview/prd.json
+++ b/plans/sprints/2026-06-20-public-want-list-mobile-preview/prd.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "../../prd.schema.json",
+  "project": {
+    "name": "Public Want List Mobile Preview",
+    "repoRoot": "/Users/petereilly2021/Projects/barrelbook-website-public-want-list-page"
+  },
+  "definitionOfDone": {
+    "required": [
+      "Mobile item cards are visibly more compact and scannable.",
+      "Artwork and placeholder sizing is consistent on mobile.",
+      "Target price and public note remain visible without oversized blocks.",
+      "Desktop layout does not regress.",
+      "Local browser preview is available before commit."
+    ]
+  },
+  "files_changed": [
+    "src/app/w/[token]/page.tsx"
+  ],
+  "items": [
+    {
+      "id": "PWLM-001",
+      "priority": 1,
+      "title": "Tighten mobile public-list item cards",
+      "description": "Adjust the public Want-list item card layout so mobile recipients can scan multiple bottles quickly.",
+      "acceptanceCriteria": [
+        "Mobile item cards use a compact row layout.",
+        "Bottle artwork is smaller and aligned with item copy.",
+        "Rank, title, tags, target price, and public note fit without excessive empty space.",
+        "Desktop layout remains card-based and readable."
+      ],
+      "passes": true,
+      "tags": ["website", "mobile", "public-share"]
+    },
+    {
+      "id": "PWLM-002",
+      "priority": 1,
+      "title": "Preview the layout locally",
+      "description": "Run the website locally with public-list data and open it in a browser for visual approval.",
+      "acceptanceCriteria": [
+        "A local preview URL is available.",
+        "Mobile and desktop screenshots or visual checks are completed.",
+        "No production backend change is required for the preview."
+      ],
+      "passes": true,
+      "tags": ["preview", "verification"]
+    }
+  ]
+}

--- a/plans/sprints/2026-06-20-public-want-list-mobile-preview/progress.txt
+++ b/plans/sprints/2026-06-20-public-want-list-mobile-preview/progress.txt
@@ -1,0 +1,41 @@
+Public Want List Mobile Preview
+=====================================================
+
+Started: 2026-06-20
+Status: Preview Ready (2/2 items)
+
+## Goals
+- Preview a more compact mobile layout for `/w/[token]`.
+- Keep the patch limited to website presentation.
+- Do not commit until the visual direction is approved.
+
+## Items
+
+### Priority 1
+- [x] PWLM-001: Tighten mobile public-list item cards
+- [x] PWLM-002: Preview the layout locally
+
+## Files to Modify
+- src/app/w/[token]/page.tsx
+
+## Verification
+- npm run build
+- Local browser preview at mobile and desktop widths
+
+## Results
+- `npm run build` passed.
+- Local preview opened at `http://127.0.0.1:3044/w/preview-token`.
+- Mobile screenshot: `output/playwright/public-want-mobile-preview.png`.
+- Comment-width screenshot: `output/playwright/public-want-comment-width-preview.png`.
+- Desktop screenshot: `output/playwright/public-want-desktop-preview.png`.
+- Second pass removed brand/type from the visible card metadata, kept public notes under the bottle name, and made target price a right-side mobile tile.
+- `curl http://127.0.0.1:3044/w/preview-token` confirmed `1792 • Bourbon` is no longer present while public note and target labels still render.
+- Third pass vertically centered the item text stack against the bottle artwork and target tile.
+- Comment-width screenshot: `output/playwright/public-want-comment-width-centered.png`.
+- Fourth pass moved rank into a larger dedicated left column before the bottle artwork.
+- Left-rank screenshot: `output/playwright/public-want-comment-width-left-rank-large.png`.
+- Fifth pass rendered optional `ownerDisplayName` as the header eyebrow, e.g. `Pete Reilly's Shared Want List`.
+- Owner-name screenshot: `output/playwright/public-want-owner-name-preview.png`.
+
+## Deployment
+- No deploy until the preview is approved.

--- a/plans/sprints/2026-06-20-public-want-list-mobile-preview/prompt.md
+++ b/plans/sprints/2026-06-20-public-want-list-mobile-preview/prompt.md
@@ -1,0 +1,20 @@
+# Public Want List Mobile Preview
+
+Implement a compact mobile preview for the public Want-list page at `/w/[token]`.
+
+## Constraints
+- Keep the existing public-share data contract.
+- Do not change backend behavior.
+- Keep security headers and `cache: "no-store"` behavior untouched.
+- Keep the desktop layout readable.
+- Do not commit until Pete approves the visual direction.
+
+## Verification Commands
+```bash
+npm run build
+```
+
+## Browser Preview
+- Run the website locally.
+- Use mock public-list data if an active production token is unavailable.
+- Check mobile and desktop widths.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
-import { GoogleAnalytics } from "@next/third-parties/google";
-import { Analytics } from "@vercel/analytics/react";
+import { RouteAnalytics } from "@/components/RouteAnalytics";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -63,8 +62,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
-        <Analytics />
-        {googleAnalyticsId ? <GoogleAnalytics gaId={googleAnalyticsId} /> : null}
+        <RouteAnalytics googleAnalyticsId={googleAnalyticsId} />
       </body>
     </html>
   );

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -8,6 +8,7 @@ export default function robots(): MetadataRoute.Robots {
       disallow: [
         '/p/',
         '/qa/',
+        '/w/',
         // Plan Task 4: approval assets are direct-link only, not public discovery.
         '/openai-approval/',
         '/blackshirt',

--- a/src/app/w/[token]/page.tsx
+++ b/src/app/w/[token]/page.tsx
@@ -173,10 +173,6 @@ function parseSnapshot(payload: unknown): PublicWantListSnapshot {
         .sort((left, right) => left.rank - right.rank)
     : [];
 
-  if (items.length === 0) {
-    return UNAVAILABLE_SNAPSHOT;
-  }
-
   return {
     status: "active",
     listName: cleanText(data.listName, 120) || "Shared Want List",
@@ -388,11 +384,15 @@ function ActiveWantListView({
             </div>
           </div>
 
-          <ol className="mt-8 space-y-4">
-            {snapshot.items.map((item, index) => (
-              <WantListItemRow key={`${item.rank}-${item.displayName}-${index}`} item={item} />
-            ))}
-          </ol>
+          {snapshot.items.length > 0 ? (
+            <ol className="mt-8 space-y-4">
+              {snapshot.items.map((item, index) => (
+                <WantListItemRow key={`${item.rank}-${item.displayName}-${index}`} item={item} />
+              ))}
+            </ol>
+          ) : (
+            <EmptyWantListState />
+          )}
         </div>
 
         <aside className="rounded-lg border border-[#333333] bg-[#111111] p-5 shadow-[0_24px_70px_rgba(0,0,0,0.28)] sm:p-6 lg:sticky lg:top-6">
@@ -421,6 +421,19 @@ function ActiveWantListView({
         </aside>
       </div>
     </section>
+  );
+}
+
+function EmptyWantListState() {
+  return (
+    <div className="mt-8 rounded-lg border border-[#2C2C2C] bg-[#111111] p-5">
+      <div className="text-sm font-semibold uppercase tracking-[0.16em] text-[#F2C19A]">
+        No public bottles yet
+      </div>
+      <p className="mt-3 text-base leading-7 text-[#CFCFCF]">
+        This shared list is active, but no bottles are currently visible to recipients.
+      </p>
+    </div>
   );
 }
 

--- a/src/app/w/[token]/page.tsx
+++ b/src/app/w/[token]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
 import type { ReactNode } from "react";
-import { APP_STORE_APP_ID, APP_STORE_URL } from "@/lib/app-store";
+import { APP_STORE_URL } from "@/lib/app-store";
 
 type WantListPageProps = {
   params: Promise<{
@@ -69,14 +69,6 @@ function decodeRouteValue(value: string): string {
 
 function normalizeShareToken(token: string): string {
   return decodeRouteValue(token).trim();
-}
-
-function getEncodedShareToken(token: string): string {
-  return encodeURIComponent(normalizeShareToken(token));
-}
-
-function getWantListAppOpenUrl(token: string): string {
-  return `barrelbook://w/${getEncodedShareToken(token)}`;
 }
 
 function getPublicWantListEndpoint(): string {
@@ -293,20 +285,13 @@ function getPlaceholderInitials(item: PublicWantListItem): string {
   return `${words[0][0]}${words[1][0]}`.toUpperCase();
 }
 
-export async function generateMetadata({
-  params,
-}: WantListPageProps): Promise<Metadata> {
-  const { token } = await params;
-  const appOpenUrl = getWantListAppOpenUrl(token);
+export function generateMetadata(): Metadata {
   const description =
-    "View a shared BarrelBook Want list, then open BarrelBook to build or manage your own whiskey list.";
+    "View a shared BarrelBook Want list, then get BarrelBook to build or manage your own whiskey list.";
 
   return {
     title: "Shared Want List",
     description,
-    other: {
-      "apple-itunes-app": `app-id=${APP_STORE_APP_ID}, app-argument=${appOpenUrl}`,
-    },
     robots: {
       index: false,
       follow: false,
@@ -328,7 +313,6 @@ export async function generateMetadata({
 export default async function WantListPage({ params }: WantListPageProps) {
   const { token } = await params;
   const snapshot = await fetchPublicWantListShare(token);
-  const appOpenUrl = getWantListAppOpenUrl(token);
 
   return (
     <main className="min-h-screen bg-[#0A0A0A] text-white">
@@ -356,9 +340,9 @@ export default async function WantListPage({ params }: WantListPageProps) {
       </header>
 
       {snapshot.status === "active" ? (
-        <ActiveWantListView snapshot={snapshot} appOpenUrl={appOpenUrl} />
+        <ActiveWantListView snapshot={snapshot} />
       ) : (
-        <UnavailableWantListView appOpenUrl={appOpenUrl} />
+        <UnavailableWantListView />
       )}
     </main>
   );
@@ -366,10 +350,8 @@ export default async function WantListPage({ params }: WantListPageProps) {
 
 function ActiveWantListView({
   snapshot,
-  appOpenUrl,
 }: {
   snapshot: Extract<PublicWantListSnapshot, { status: "active" }>;
-  appOpenUrl: string;
 }) {
   const updatedDate = formatUpdatedDate(snapshot.updatedAt);
 
@@ -418,16 +400,10 @@ function ActiveWantListView({
           </p>
           <div className="mt-6 flex flex-col gap-3">
             <a
-              href={appOpenUrl}
-              className="inline-flex min-h-11 w-full items-center justify-center rounded-full bg-[#D2691E] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#B85714]"
-            >
-              Open in BarrelBook
-            </a>
-            <a
               href={APP_STORE_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex min-h-11 w-full items-center justify-center rounded-full border border-[#D2691E]/45 bg-transparent px-5 py-3 text-base font-semibold text-white transition hover:border-[#D2691E] hover:bg-[#D2691E]/10"
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-full bg-[#D2691E] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#B85714]"
             >
               Get BarrelBook
             </a>
@@ -524,7 +500,7 @@ function ItemPill({ children }: { children: ReactNode }) {
   );
 }
 
-function UnavailableWantListView({ appOpenUrl }: { appOpenUrl: string }) {
+function UnavailableWantListView() {
   return (
     <section className="px-4 py-12 sm:px-6 lg:px-8 lg:py-20">
       <div className="mx-auto max-w-3xl">
@@ -540,16 +516,10 @@ function UnavailableWantListView({ appOpenUrl }: { appOpenUrl: string }) {
           </p>
           <div className="mt-7 flex flex-col gap-3 sm:flex-row">
             <a
-              href={appOpenUrl}
-              className="inline-flex min-h-11 items-center justify-center rounded-full bg-[#D2691E] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#B85714]"
-            >
-              Open BarrelBook
-            </a>
-            <a
               href={APP_STORE_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex min-h-11 items-center justify-center rounded-full border border-[#D2691E]/45 bg-transparent px-5 py-3 text-base font-semibold text-white transition hover:border-[#D2691E] hover:bg-[#D2691E]/10"
+              className="inline-flex min-h-11 items-center justify-center rounded-full bg-[#D2691E] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#B85714]"
             >
               Get BarrelBook
             </a>

--- a/src/app/w/[token]/page.tsx
+++ b/src/app/w/[token]/page.tsx
@@ -27,6 +27,7 @@ type PublicWantListSnapshot =
   | {
       status: "active";
       listName: string;
+      listDescription: string | null;
       listType: "want";
       updatedAt: PublicTimestamp;
       items: PublicWantListItem[];
@@ -43,6 +44,9 @@ const UNAVAILABLE_SNAPSHOT: PublicWantListSnapshot = {
   status: "unavailable",
   items: [],
 };
+
+const DEFAULT_WANT_LIST_DESCRIPTION =
+  "A ranked BarrelBook Want list shared for gift ideas, store runs, or bottles worth watching.";
 
 const PLACEHOLDER_PALETTES = [
   ["#3A1D0D", "#D2691E", "#F2C19A"],
@@ -176,6 +180,7 @@ function parseSnapshot(payload: unknown): PublicWantListSnapshot {
   return {
     status: "active",
     listName: cleanText(data.listName, 120) || "Shared Want List",
+    listDescription: cleanText(data.listDescription, 240),
     listType: "want",
     updatedAt: isSupportedTimestamp(data.updatedAt) ? data.updatedAt : null,
     items,
@@ -368,7 +373,7 @@ function ActiveWantListView({
                 {snapshot.listName}
               </h1>
               <p className="mt-3 max-w-2xl text-base leading-7 text-[#CFCFCF]">
-                A ranked BarrelBook Want list shared for gift ideas, store runs, or bottles worth watching.
+                {snapshot.listDescription || DEFAULT_WANT_LIST_DESCRIPTION}
               </p>
             </div>
             <div className="flex shrink-0 flex-wrap gap-2 text-sm text-[#D4D4D4]">

--- a/src/app/w/[token]/page.tsx
+++ b/src/app/w/[token]/page.tsx
@@ -1,0 +1,566 @@
+import type { Metadata } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { APP_STORE_APP_ID, APP_STORE_URL } from "@/lib/app-store";
+
+type WantListPageProps = {
+  params: Promise<{
+    token: string;
+  }>;
+};
+
+type PublicWantListItem = {
+  rank: number;
+  displayName: string;
+  brand: string | null;
+  bottleType: string | null;
+  targetPrice: number | string | null;
+  publicNote: string | null;
+  thumbnailUrl: string | null;
+  placeholderSeed: string | null;
+};
+
+type PublicTimestamp = string | number | Record<string, unknown> | null;
+
+type PublicWantListSnapshot =
+  | {
+      status: "active";
+      listName: string;
+      listType: "want";
+      updatedAt: PublicTimestamp;
+      items: PublicWantListItem[];
+    }
+  | {
+      status: "unavailable";
+      items: [];
+    };
+
+const DEFAULT_PUBLIC_WANT_LIST_ENDPOINT =
+  "https://us-central1-barrelbook-273cd.cloudfunctions.net/getPublicWantListShare";
+
+const UNAVAILABLE_SNAPSHOT: PublicWantListSnapshot = {
+  status: "unavailable",
+  items: [],
+};
+
+const PLACEHOLDER_PALETTES = [
+  ["#3A1D0D", "#D2691E", "#F2C19A"],
+  ["#18211A", "#497A4B", "#D9E8C8"],
+  ["#151E2B", "#4F7EA8", "#D4E7F7"],
+  ["#2A1720", "#A84F6A", "#F1CED8"],
+  ["#241F17", "#8F7650", "#E6D6B8"],
+] as const;
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeRouteValue(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function normalizeShareToken(token: string): string {
+  return decodeRouteValue(token).trim();
+}
+
+function getEncodedShareToken(token: string): string {
+  return encodeURIComponent(normalizeShareToken(token));
+}
+
+function getWantListAppOpenUrl(token: string): string {
+  return `barrelbook://w/${getEncodedShareToken(token)}`;
+}
+
+function getPublicWantListEndpoint(): string {
+  return (
+    process.env.BARRELBOOK_PUBLIC_WANT_LIST_ENDPOINT_URL?.trim() ||
+    process.env.BARRELBOOK_PUBLIC_SHARE_ENDPOINT_URL?.trim() ||
+    DEFAULT_PUBLIC_WANT_LIST_ENDPOINT
+  );
+}
+
+function cleanText(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const cleaned = value.replace(/\s+/g, " ").trim();
+  if (!cleaned) return null;
+  return cleaned.slice(0, maxLength);
+}
+
+function parseRank(value: unknown, fallback: number): number {
+  const numeric =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseInt(value, 10)
+        : Number.NaN;
+
+  if (!Number.isFinite(numeric) || numeric < 1) {
+    return fallback;
+  }
+
+  return Math.floor(numeric);
+}
+
+function parseTargetPrice(value: unknown): number | string | null {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const cleaned = value.trim();
+    if (!cleaned) return null;
+
+    const numeric = Number.parseFloat(cleaned.replace(/[^0-9.]/g, ""));
+    if (Number.isFinite(numeric) && numeric > 0) {
+      return numeric;
+    }
+  }
+
+  return null;
+}
+
+function parseHttpsUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:") return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function parseItem(value: unknown, fallbackRank: number): PublicWantListItem | null {
+  if (!isRecord(value)) return null;
+
+  const displayName = cleanText(value.displayName, 160);
+  if (!displayName) return null;
+
+  return {
+    rank: parseRank(value.rank, fallbackRank),
+    displayName,
+    brand: cleanText(value.brand, 120),
+    bottleType: cleanText(value.bottleType, 80),
+    targetPrice: parseTargetPrice(value.targetPrice),
+    publicNote: cleanText(value.publicNote, 300),
+    thumbnailUrl: parseHttpsUrl(value.thumbnailUrl),
+    placeholderSeed: cleanText(value.placeholderSeed, 120),
+  };
+}
+
+function parseSnapshot(payload: unknown): PublicWantListSnapshot {
+  if (!isRecord(payload)) return UNAVAILABLE_SNAPSHOT;
+
+  const data = isRecord(payload.data) ? payload.data : null;
+  if (!data || data.status !== "active") {
+    return UNAVAILABLE_SNAPSHOT;
+  }
+
+  const listType = cleanText(data.listType, 40);
+  if (listType && listType !== "want") {
+    return UNAVAILABLE_SNAPSHOT;
+  }
+
+  const items = Array.isArray(data.items)
+    ? data.items
+        .map((item, index) => parseItem(item, index + 1))
+        .filter((item): item is PublicWantListItem => item !== null)
+        .sort((left, right) => left.rank - right.rank)
+    : [];
+
+  if (items.length === 0) {
+    return UNAVAILABLE_SNAPSHOT;
+  }
+
+  return {
+    status: "active",
+    listName: cleanText(data.listName, 120) || "Shared Want List",
+    listType: "want",
+    updatedAt: isSupportedTimestamp(data.updatedAt) ? data.updatedAt : null,
+    items,
+  };
+}
+
+function isSupportedTimestamp(value: unknown): value is string | number | Record<string, unknown> {
+  if (typeof value === "string" || typeof value === "number") return true;
+  return isRecord(value);
+}
+
+async function fetchPublicWantListShare(token: string): Promise<PublicWantListSnapshot> {
+  const normalizedToken = normalizeShareToken(token);
+  if (!normalizedToken) return UNAVAILABLE_SNAPSHOT;
+
+  try {
+    const response = await fetch(getPublicWantListEndpoint(), {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ token: normalizedToken }),
+      cache: "no-store",
+      next: {
+        revalidate: 0,
+      },
+    });
+
+    if (!response.ok) {
+      return UNAVAILABLE_SNAPSHOT;
+    }
+
+    const payload: unknown = await response.json();
+    return parseSnapshot(payload);
+  } catch {
+    return UNAVAILABLE_SNAPSHOT;
+  }
+}
+
+function timestampToDate(value: PublicTimestamp): Date | null {
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  if (isRecord(value)) {
+    const seconds = value.seconds ?? value._seconds;
+    if (typeof seconds === "number") {
+      const date = new Date(seconds * 1000);
+      return Number.isNaN(date.getTime()) ? null : date;
+    }
+  }
+
+  return null;
+}
+
+function formatUpdatedDate(value: PublicTimestamp): string | null {
+  const date = timestampToDate(value);
+  if (!date) return null;
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+function formatTargetPrice(value: PublicWantListItem["targetPrice"]): string | null {
+  if (value === null) return null;
+
+  const numeric =
+    typeof value === "number"
+      ? value
+      : Number.parseFloat(value.replace(/[^0-9.]/g, ""));
+
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: Number.isInteger(numeric) ? 0 : 2,
+  }).format(numeric);
+}
+
+function hashText(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+function getPlaceholderPalette(item: PublicWantListItem) {
+  const seed = item.placeholderSeed || item.displayName;
+  return PLACEHOLDER_PALETTES[hashText(seed) % PLACEHOLDER_PALETTES.length];
+}
+
+function getPlaceholderInitials(item: PublicWantListItem): string {
+  const source = item.brand || item.displayName;
+  const words = source
+    .split(/\s+/)
+    .map((word) => word.replace(/[^A-Za-z0-9]/g, ""))
+    .filter(Boolean);
+
+  if (words.length === 0) return "BB";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return `${words[0][0]}${words[1][0]}`.toUpperCase();
+}
+
+export async function generateMetadata({
+  params,
+}: WantListPageProps): Promise<Metadata> {
+  const { token } = await params;
+  const appOpenUrl = getWantListAppOpenUrl(token);
+  const description =
+    "View a shared BarrelBook Want list, then open BarrelBook to build or manage your own whiskey list.";
+
+  return {
+    title: "Shared Want List",
+    description,
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_APP_ID}, app-argument=${appOpenUrl}`,
+    },
+    robots: {
+      index: false,
+      follow: false,
+      noarchive: true,
+    },
+    openGraph: {
+      type: "website",
+      title: "Shared BarrelBook Want List",
+      description,
+    },
+    twitter: {
+      card: "summary",
+      title: "Shared BarrelBook Want List",
+      description,
+    },
+  };
+}
+
+export default async function WantListPage({ params }: WantListPageProps) {
+  const { token } = await params;
+  const snapshot = await fetchPublicWantListShare(token);
+  const appOpenUrl = getWantListAppOpenUrl(token);
+
+  return (
+    <main className="min-h-screen bg-[#0A0A0A] text-white">
+      <header className="border-b border-[#333333] bg-[#0A0A0A]/95 backdrop-blur-md">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-4 sm:px-6 lg:px-8">
+          <Link href="/" className="flex items-center gap-3" aria-label="BarrelBook home">
+            <Image
+              src="/BarrelBook%20Logo%20Large.png"
+              alt="BarrelBook"
+              width={220}
+              height={48}
+              className="h-8 w-auto"
+              priority
+            />
+          </Link>
+          <a
+            href={APP_STORE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex min-h-11 items-center rounded-full border border-[#D2691E]/40 bg-[#D2691E]/10 px-4 py-2 text-sm font-medium text-white transition hover:border-[#D2691E] hover:bg-[#D2691E]/20"
+          >
+            Get BarrelBook
+          </a>
+        </div>
+      </header>
+
+      {snapshot.status === "active" ? (
+        <ActiveWantListView snapshot={snapshot} appOpenUrl={appOpenUrl} />
+      ) : (
+        <UnavailableWantListView appOpenUrl={appOpenUrl} />
+      )}
+    </main>
+  );
+}
+
+function ActiveWantListView({
+  snapshot,
+  appOpenUrl,
+}: {
+  snapshot: Extract<PublicWantListSnapshot, { status: "active" }>;
+  appOpenUrl: string;
+}) {
+  const updatedDate = formatUpdatedDate(snapshot.updatedAt);
+
+  return (
+    <section className="px-4 py-8 sm:px-6 lg:px-8 lg:py-12">
+      <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
+        <div>
+          <div className="text-sm font-semibold uppercase tracking-[0.2em] text-[#F2C19A]">
+            Shared Want List
+          </div>
+          <div className="mt-3 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="max-w-3xl text-3xl font-semibold leading-tight tracking-tight text-white sm:text-4xl">
+                {snapshot.listName}
+              </h1>
+              <p className="mt-3 max-w-2xl text-base leading-7 text-[#CFCFCF]">
+                A ranked BarrelBook Want list shared for gift ideas, store runs, or bottles worth watching.
+              </p>
+            </div>
+            <div className="flex shrink-0 flex-wrap gap-2 text-sm text-[#D4D4D4]">
+              <span className="rounded-full border border-[#333333] bg-[#141414] px-3 py-2">
+                {snapshot.items.length} {snapshot.items.length === 1 ? "bottle" : "bottles"}
+              </span>
+              {updatedDate ? (
+                <span className="rounded-full border border-[#333333] bg-[#141414] px-3 py-2">
+                  Updated {updatedDate}
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          <ol className="mt-8 space-y-4">
+            {snapshot.items.map((item, index) => (
+              <WantListItemRow key={`${item.rank}-${item.displayName}-${index}`} item={item} />
+            ))}
+          </ol>
+        </div>
+
+        <aside className="rounded-lg border border-[#333333] bg-[#111111] p-5 shadow-[0_24px_70px_rgba(0,0,0,0.28)] sm:p-6 lg:sticky lg:top-6">
+          <div className="text-sm font-semibold uppercase tracking-[0.18em] text-[#F2C19A]">
+            Powered by BarrelBook
+          </div>
+          <h2 className="mt-3 text-2xl font-semibold text-white">Keep your bottle list in your pocket.</h2>
+          <p className="mt-3 text-base leading-7 text-[#CFCFCF]">
+            BarrelBook helps whiskey collectors scan bottles, track prices, and build lists they can use at stores, tastings, and with friends.
+          </p>
+          <div className="mt-6 flex flex-col gap-3">
+            <a
+              href={appOpenUrl}
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-full bg-[#D2691E] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#B85714]"
+            >
+              Open in BarrelBook
+            </a>
+            <a
+              href={APP_STORE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-11 w-full items-center justify-center rounded-full border border-[#D2691E]/45 bg-transparent px-5 py-3 text-base font-semibold text-white transition hover:border-[#D2691E] hover:bg-[#D2691E]/10"
+            >
+              Get BarrelBook
+            </a>
+          </div>
+          <div className="mt-6 rounded-lg border border-[#D2691E]/30 bg-[#0A0A0A] p-4">
+            <p className="text-sm leading-6 text-[#D4D4D4]">
+              This page shows only the public fields the list owner chose to share. Private notes and collection details stay in BarrelBook.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function WantListItemRow({ item }: { item: PublicWantListItem }) {
+  const targetPrice = formatTargetPrice(item.targetPrice);
+
+  return (
+    <li className="rounded-lg border border-[#2C2C2C] bg-[#111111] p-4 sm:p-5">
+      <div className="grid gap-4 sm:grid-cols-[96px_minmax(0,1fr)] sm:items-start">
+        <BottleArtwork item={item} />
+        <div className="min-w-0">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="text-sm font-semibold uppercase tracking-[0.18em] text-[#F2C19A]">
+                #{item.rank}
+              </div>
+              <h2 className="mt-1 text-2xl font-semibold leading-tight text-white">
+                {item.displayName}
+              </h2>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {item.brand ? <ItemPill>{item.brand}</ItemPill> : null}
+                {item.bottleType ? <ItemPill>{item.bottleType}</ItemPill> : null}
+              </div>
+            </div>
+            {targetPrice ? (
+              <div className="shrink-0 rounded-lg border border-[#D2691E]/35 bg-[#2A1B11] px-4 py-3 text-left sm:text-right">
+                <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[#F2C19A]">
+                  Target
+                </div>
+                <div className="mt-1 text-xl font-semibold text-white">{targetPrice}</div>
+              </div>
+            ) : null}
+          </div>
+
+          {item.publicNote ? (
+            <p className="mt-4 rounded-lg border border-[#2F2F2F] bg-[#0A0A0A] px-4 py-3 text-base leading-7 text-[#D4D4D4]">
+              {item.publicNote}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function BottleArtwork({ item }: { item: PublicWantListItem }) {
+  if (item.thumbnailUrl) {
+    return (
+      <div className="relative h-24 w-24 overflow-hidden rounded-lg border border-[#333333] bg-[#151515]">
+        <div
+          aria-label={`${item.displayName} thumbnail`}
+          className="h-full w-full bg-cover bg-center"
+          role="img"
+          style={{ backgroundImage: `url(${item.thumbnailUrl})` }}
+        />
+      </div>
+    );
+  }
+
+  const [from, to, text] = getPlaceholderPalette(item);
+
+  return (
+    <div
+      className="flex h-24 w-24 items-center justify-center rounded-lg border border-[#333333] text-xl font-semibold"
+      style={{
+        background: `linear-gradient(145deg, ${from}, ${to})`,
+        color: text,
+      }}
+      aria-label={`${item.displayName} placeholder`}
+      role="img"
+    >
+      {getPlaceholderInitials(item)}
+    </div>
+  );
+}
+
+function ItemPill({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full border border-[#333333] bg-[#171717] px-3 py-1 text-sm text-[#D4D4D4]">
+      {children}
+    </span>
+  );
+}
+
+function UnavailableWantListView({ appOpenUrl }: { appOpenUrl: string }) {
+  return (
+    <section className="px-4 py-12 sm:px-6 lg:px-8 lg:py-20">
+      <div className="mx-auto max-w-3xl">
+        <div className="rounded-lg border border-[#333333] bg-[#111111] p-6 shadow-[0_24px_70px_rgba(0,0,0,0.28)] sm:p-8">
+          <div className="text-sm font-semibold uppercase tracking-[0.2em] text-[#F2C19A]">
+            BarrelBook Want List
+          </div>
+          <h1 className="mt-4 text-3xl font-semibold leading-tight tracking-tight text-white sm:text-4xl">
+            This shared list is unavailable.
+          </h1>
+          <p className="mt-4 text-base leading-7 text-[#CFCFCF]">
+            The link may be expired, revoked, or mistyped. To protect collectors&apos; privacy, BarrelBook does not confirm whether a specific list exists.
+          </p>
+          <div className="mt-7 flex flex-col gap-3 sm:flex-row">
+            <a
+              href={appOpenUrl}
+              className="inline-flex min-h-11 items-center justify-center rounded-full bg-[#D2691E] px-5 py-3 text-base font-semibold text-white transition hover:bg-[#B85714]"
+            >
+              Open BarrelBook
+            </a>
+            <a
+              href={APP_STORE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-11 items-center justify-center rounded-full border border-[#D2691E]/45 bg-transparent px-5 py-3 text-base font-semibold text-white transition hover:border-[#D2691E] hover:bg-[#D2691E]/10"
+            >
+              Get BarrelBook
+            </a>
+          </div>
+          <div className="mt-7 rounded-lg border border-[#D2691E]/30 bg-[#0A0A0A] p-4">
+            <p className="text-sm leading-6 text-[#D4D4D4]">
+              BarrelBook public list pages only show recipient-safe fields chosen by the list owner.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/w/[token]/page.tsx
+++ b/src/app/w/[token]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import type { ReactNode } from "react";
 import { APP_STORE_URL } from "@/lib/app-store";
 
 type WantListPageProps = {
@@ -28,6 +27,7 @@ type PublicWantListSnapshot =
       status: "active";
       listName: string;
       listDescription: string | null;
+      ownerDisplayName: string | null;
       listType: "want";
       updatedAt: PublicTimestamp;
       items: PublicWantListItem[];
@@ -177,6 +177,7 @@ function parseSnapshot(payload: unknown): PublicWantListSnapshot {
     status: "active",
     listName: cleanText(data.listName, 120) || "Shared Want List",
     listDescription: cleanText(data.listDescription, 240),
+    ownerDisplayName: cleanText(data.ownerDisplayName, 80),
     listType: "want",
     updatedAt: isSupportedTimestamp(data.updatedAt) ? data.updatedAt : null,
     items,
@@ -259,6 +260,16 @@ function formatTargetPrice(value: PublicWantListItem["targetPrice"]): string | n
     currency: "USD",
     maximumFractionDigits: Number.isInteger(numeric) ? 0 : 2,
   }).format(numeric);
+}
+
+function possessiveName(value: string): string {
+  return /s$/i.test(value) ? `${value}'` : `${value}'s`;
+}
+
+function formatWantListEyebrow(ownerDisplayName: string | null): string {
+  return ownerDisplayName
+    ? `${possessiveName(ownerDisplayName)} Shared Want List`
+    : "Shared Want List";
 }
 
 function hashText(value: string): number {
@@ -355,13 +366,14 @@ function ActiveWantListView({
   snapshot: Extract<PublicWantListSnapshot, { status: "active" }>;
 }) {
   const updatedDate = formatUpdatedDate(snapshot.updatedAt);
+  const eyebrow = formatWantListEyebrow(snapshot.ownerDisplayName);
 
   return (
     <section className="px-4 py-8 sm:px-6 lg:px-8 lg:py-12">
       <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start">
         <div>
-          <div className="text-sm font-semibold uppercase tracking-[0.2em] text-[#F2C19A]">
-            Shared Want List
+          <div className="text-sm font-semibold tracking-[0.08em] text-[#F2C19A]">
+            {eyebrow}
           </div>
           <div className="mt-3 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
@@ -385,7 +397,7 @@ function ActiveWantListView({
           </div>
 
           {snapshot.items.length > 0 ? (
-            <ol className="mt-8 space-y-4">
+            <ol className="mt-6 space-y-3 sm:mt-8 sm:space-y-4">
               {snapshot.items.map((item, index) => (
                 <WantListItemRow key={`${item.rank}-${item.displayName}-${index}`} item={item} />
               ))}
@@ -441,38 +453,38 @@ function WantListItemRow({ item }: { item: PublicWantListItem }) {
   const targetPrice = formatTargetPrice(item.targetPrice);
 
   return (
-    <li className="rounded-lg border border-[#2C2C2C] bg-[#111111] p-4 sm:p-5">
-      <div className="grid gap-4 sm:grid-cols-[96px_minmax(0,1fr)] sm:items-start">
+    <li className="rounded-lg border border-[#2C2C2C] bg-[#111111] p-3 sm:p-5">
+      <div className="grid grid-cols-[2.25rem_80px_minmax(0,1fr)] items-center gap-2 sm:grid-cols-[3rem_96px_minmax(0,1fr)] sm:gap-4">
+        <div
+          aria-label={`Rank ${item.rank}`}
+          className="text-center text-3xl font-semibold leading-none tabular-nums text-[#F2C19A] sm:text-4xl"
+        >
+          {item.rank}
+        </div>
         <BottleArtwork item={item} />
         <div className="min-w-0">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="min-w-0">
-              <div className="text-sm font-semibold uppercase tracking-[0.18em] text-[#F2C19A]">
-                #{item.rank}
-              </div>
-              <h2 className="mt-1 text-2xl font-semibold leading-tight text-white">
+          <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 sm:flex sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0 self-center">
+              <h2 className="break-words text-xl font-semibold leading-tight text-white sm:text-2xl">
                 {item.displayName}
               </h2>
-              <div className="mt-3 flex flex-wrap gap-2">
-                {item.brand ? <ItemPill>{item.brand}</ItemPill> : null}
-                {item.bottleType ? <ItemPill>{item.bottleType}</ItemPill> : null}
-              </div>
+              {item.publicNote ? (
+                <p className="mt-1 text-sm leading-5 text-[#D4D4D4] sm:mt-1.5 sm:text-base sm:leading-6">
+                  {item.publicNote}
+                </p>
+              ) : null}
             </div>
             {targetPrice ? (
-              <div className="shrink-0 rounded-lg border border-[#D2691E]/35 bg-[#2A1B11] px-4 py-3 text-left sm:text-right">
-                <div className="text-xs font-semibold uppercase tracking-[0.16em] text-[#F2C19A]">
+              <div className="flex h-20 w-20 shrink-0 flex-col justify-center rounded-md border border-[#D2691E]/35 bg-[#2A1B11] px-3 py-2 text-left sm:h-auto sm:w-auto sm:rounded-lg sm:px-4 sm:py-3 sm:text-right">
+                <div className="text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-[#F2C19A] sm:text-xs">
                   Target
                 </div>
-                <div className="mt-1 text-xl font-semibold text-white">{targetPrice}</div>
+                <div className="mt-0.5 text-base font-semibold text-white sm:mt-1 sm:text-xl">
+                  {targetPrice}
+                </div>
               </div>
             ) : null}
           </div>
-
-          {item.publicNote ? (
-            <p className="mt-4 rounded-lg border border-[#2F2F2F] bg-[#0A0A0A] px-4 py-3 text-base leading-7 text-[#D4D4D4]">
-              {item.publicNote}
-            </p>
-          ) : null}
         </div>
       </div>
     </li>
@@ -482,7 +494,7 @@ function WantListItemRow({ item }: { item: PublicWantListItem }) {
 function BottleArtwork({ item }: { item: PublicWantListItem }) {
   if (item.thumbnailUrl) {
     return (
-      <div className="relative h-24 w-24 overflow-hidden rounded-lg border border-[#333333] bg-[#151515]">
+      <div className="relative h-20 w-20 overflow-hidden rounded-md border border-[#333333] bg-[#151515] sm:h-24 sm:w-24 sm:rounded-lg">
         <div
           aria-label={`${item.displayName} thumbnail`}
           className="h-full w-full bg-cover bg-center"
@@ -497,7 +509,7 @@ function BottleArtwork({ item }: { item: PublicWantListItem }) {
 
   return (
     <div
-      className="flex h-24 w-24 items-center justify-center rounded-lg border border-[#333333] text-xl font-semibold"
+      className="flex h-20 w-20 items-center justify-center rounded-md border border-[#333333] text-lg font-semibold sm:h-24 sm:w-24 sm:rounded-lg sm:text-xl"
       style={{
         background: `linear-gradient(145deg, ${from}, ${to})`,
         color: text,
@@ -507,14 +519,6 @@ function BottleArtwork({ item }: { item: PublicWantListItem }) {
     >
       {getPlaceholderInitials(item)}
     </div>
-  );
-}
-
-function ItemPill({ children }: { children: ReactNode }) {
-  return (
-    <span className="rounded-full border border-[#333333] bg-[#171717] px-3 py-1 text-sm text-[#D4D4D4]">
-      {children}
-    </span>
   );
 }
 

--- a/src/components/RouteAnalytics.tsx
+++ b/src/components/RouteAnalytics.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { GoogleAnalytics } from "@next/third-parties/google";
+import { Analytics } from "@vercel/analytics/react";
+import { usePathname } from "next/navigation";
+
+type RouteAnalyticsProps = {
+  googleAnalyticsId?: string;
+};
+
+function isTokenizedPublicWantListPath(pathname: string): boolean {
+  return pathname === "/w" || pathname.startsWith("/w/");
+}
+
+export function RouteAnalytics({ googleAnalyticsId }: RouteAnalyticsProps) {
+  const pathname = usePathname();
+
+  if (isTokenizedPublicWantListPath(pathname)) {
+    return null;
+  }
+
+  return (
+    <>
+      <Analytics />
+      {googleAnalyticsId ? <GoogleAnalytics gaId={googleAnalyticsId} /> : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Add the server-rendered `/w/[token]` public recipient route.
- Fetch sanitized snapshots from `getPublicWantListShare` with no-store caching and neutral unavailable fallback.
- Add noindex/noarchive metadata and exclude `/w/` from robots discovery.
- Refine the approved public Want-list layout: owner-name eyebrow, left rank rail, compact mobile rows, public notes under bottle names, right-side target tile, and no visible brand/type metadata row.

## Verification
- `npm run build` passed.
- Local browser preview with mock public-list data covered owner-name heading, left-rank layout, target price, public note, thumbnail/placeholder cases, and mobile/comment-width layouts.
- Vercel preview deployed against staging Function endpoint: https://barrelbook-website-qdmxi9iuh-pete-petereillycs-projects.vercel.app
- Production deployed and aliased to https://www.barrelbook.app

## Dependencies
- Backend PR #225 has been deployed to staging and production for `getPublicWantListShare`.

## Deployment Status
- Deployed to Vercel preview and production on June 20, 2026.
- Production URL: https://www.barrelbook.app
- The native iOS client does not need a rebuild for this website/backend response change.

## Rollback
- Redeploy previous Vercel production deployment if public page rendering regresses.
- Page falls back to `Shared Want List` when `ownerDisplayName` is omitted.
